### PR TITLE
enable VWF simulation embedding via iFrames

### DIFF
--- a/lib/vwf.rb
+++ b/lib/vwf.rb
@@ -29,11 +29,13 @@ set :component_template_types, [ :json, :yaml ]  # get from Component?
 
   configure :production do
     enable :logging
+    set :protection, :except => :frame_options # we want to be able to embed VWF into iframes so tell Sinatra to chill out on this protection
   end
 
   configure :development do
     require "logger"
     set :logging, ::Logger::DEBUG
+    set :protection, :except => :frame_options # we want to be able to embed VWF into iframes so tell Sinatra to chill out on this protection
   end
 
   get Pattern.new do |public_path, application, instance, private_path|


### PR DESCRIPTION
To embed VWF simulations in other web sites via iFrames the Sinatra default iFrame prohibition needs to be turned off

Signed-off-by: Mark McCahill mark.mccahill@duke.edu
