### PR TITLE
Wait for the application node to load before initializing the view.

### DIFF
--- a/public/tile-puzzle-2D/index.vwf.html
+++ b/public/tile-puzzle-2D/index.vwf.html
@@ -3,7 +3,15 @@
   <head>
     <title>Virtual World Framework</title>
     <script type="text/javascript">
-      var gameID = vwf.find("", "/game")[0];
+      var gameID;
+
+      vwf_view.initializedNode = function( nodeID, childID, childExtendsID, childImplementsIDs,
+          childSource, childType, childIndex, childName ) {
+        if ( childID == vwf_view.kernel.application() ) {
+          gameID = vwf_view.kernel.find("", "/game")[0];
+          initializeBoard();
+        }
+      }
 
       vwf_view.satProperty = function (nodeID, propertyName, propertyValue) {
         switch(propertyName) {
@@ -54,8 +62,6 @@
             break;
         }
       }
-
-      initializeBoard();
         
       function initializeBoard() {
         placeTile('01');


### PR DESCRIPTION
The HTML overlay previously loaded whenever it was ready, some time
after starting construction of the application tree. Some child nodes
may have already been contructed by that point, depending on timing and
whether or not they were contained in the application's component and
had other dependencies.

As of commit 12c139f, the application waits for the overlay to load
before continuing past the application root.

The tile puzzle was expecting certain child nodes to exist immediately
after the overload loaded. The fix is to wait for the application to
load (to receive `initiaizedNode`) before interacting with it.

Fixes #2720.
