### PR TITLE
Remove additional THREE.AmbientLight objects in a scene.  Fixes #2669

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -2487,32 +2487,32 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/utility/color" ], function(
             
             reg.callbacks.push( function( node ) {
             
-            //just clone the node and attach it.
-            //this should not clone the geometry, so much lower memory.
-            //seems to take near nothing to duplicated animated avatar            
-            var n = node.clone();
-			cloneMaterials( n );
-            var skins = [];
-            walkGraph( n, function( node ) {
-                if( node instanceof THREE.SkinnedMesh ) {
-                    skins.push( node );
-                }            
-            });
-            n.animatedMesh = skins;
-            nodeCopy.threeObject = n;            
-
-            nodeCopy.threeObject.matrix = new THREE.Matrix4();
-            nodeCopy.threeObject.matrixAutoUpdate = false;
-            
-            removeAmbientLights.call(this, nodeCopy.threeObject);
-
-            parentObject3.add( nodeCopy.threeObject );
-            nodeCopy.threeObject.name = childName;
-            nodeCopy.threeObject.vwfID = nodeID;
-            nodeCopy.threeObject.matrixAutoUpdate = false;
-            nodeCopy.threeObject.updateMatrixWorld( true );
-            propertyNotifyCallback();
-            nodeCopy.loadingCallback( true ); 
+                //just clone the node and attach it.
+                //this should not clone the geometry, so much lower memory.
+                //seems to take near nothing to duplicated animated avatar            
+                var n = node.clone();
+                cloneMaterials( n );
+                var skins = [];
+                walkGraph( n, function( node ) {
+                    if( node instanceof THREE.SkinnedMesh ) {
+                        skins.push( node );
+                    }            
+                });
+                n.animatedMesh = skins;
+                nodeCopy.threeObject = n;            
+    
+                nodeCopy.threeObject.matrix = new THREE.Matrix4();
+                nodeCopy.threeObject.matrixAutoUpdate = false;
+                
+                removeAmbientLights.call(this, nodeCopy.threeObject);
+    
+                parentObject3.add( nodeCopy.threeObject );
+                nodeCopy.threeObject.name = childName;
+                nodeCopy.threeObject.vwfID = nodeID;
+                nodeCopy.threeObject.matrixAutoUpdate = false;
+                nodeCopy.threeObject.updateMatrixWorld( true );
+                propertyNotifyCallback();
+                nodeCopy.loadingCallback( true ); 
             
             });
         }


### PR DESCRIPTION
The scene overexposure issue when instantiating multiple command-center apps in the same session is caused by having multiple ambient light objects in one scene. This is caused by the ColladaLoader creating a new THREE.AmbientLight object for each SceneGraph object with an ambientLight (attribute in DAE).
