### PR TITLE
Branch/resize bug

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -523,7 +523,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
             var oldMouseY = 0;
             var hovering = false;
             var view = this;
-            window.onresize = function ( ) {
+            window.onresize = function () {
                 var origWidth = self.width;
                 var origHeight = self.height;
                 if ( window && window.innerHeight ) self.height = window.innerHeight - 20;
@@ -539,7 +539,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
                     var viewCam = view.state.cameraInUse;
                     if ( viewCam ) {
                         viewCam.aspect =  mycanvas.width / mycanvas.height;
-                        viewCam.updateProjectionMatrix( );
+                        viewCam.updateProjectionMatrix();
                     }
                 }
             }


### PR DESCRIPTION
@stevencarr , @eric79 Can you two take a quick look at this pull request, to close #2800.

Setting the viewport based on the total dimensions of the webgl render canvas, as opposed to setting it to the dimensions of the actually used (ie, not including the 10 pixel border) canvas was causing bugs with mouse events producing incorrect values after resize.

Fix was to set the viewport based on the height and width with the borders removed. (also, some minor code standard fixes to the function that was touched).
