### PR TITLE
Branch/radio knobcolorfix

### DIFF
--- a/public/radio/radio.DAE
+++ b/public/radio/radio.DAE
@@ -990,79 +990,6 @@
         </technique>
       </extra>
     </effect>
-    <effect id="MultiMat_2__ic40Channel_">
-      <profile_COMMON>
-        <newparam sid="ic40channeldiffusemap_tga-surface">
-          <surface type="2D">
-            <init_from>ic40channeldiffusemap_tga</init_from>
-          </surface>
-        </newparam>
-        <newparam sid="ic40channeldiffusemap_tga-sampler">
-          <sampler2D>
-            <source>ic40channeldiffusemap_tga-surface</source>
-          </sampler2D>
-        </newparam>
-        <newparam sid="ic40channelambient_occlusion__mr__tga-surface">
-          <surface type="2D">
-            <init_from>ic40channelambient_occlusion__mr__tga</init_from>
-          </surface>
-        </newparam>
-        <newparam sid="ic40channelambient_occlusion__mr__tga-sampler">
-          <sampler2D>
-            <source>ic40channelambient_occlusion__mr__tga-surface</source>
-          </sampler2D>
-        </newparam>
-        <technique sid="common">
-          <phong>
-            <emission>
-              <color>0 0 0 1</color>
-            </emission>
-            <ambient>
-              <texture texture="ic40channeldiffusemap_tga-sampler" texcoord="CHANNEL1"/>
-            </ambient>
-            <diffuse>
-              <texture texture="ic40channelambient_occlusion__mr__tga-sampler" texcoord="CHANNEL1"/>
-            </diffuse>
-            <specular>
-              <color>0.9 0.9 0.9 1</color>
-            </specular>
-            <shininess>
-              <float>50</float>
-            </shininess>
-            <reflective>
-              <color>0 0 0 1</color>
-            </reflective>
-            <transparent opaque="A_ONE">
-              <color>1 1 1 1</color>
-            </transparent>
-            <transparency>
-              <float>1</float>
-            </transparency>
-          </phong>
-        </technique>
-      </profile_COMMON>
-      <extra>
-        <technique profile="OpenCOLLADA3dsMax">
-          <extended_shader>
-            <apply_reflection_dimming>0</apply_reflection_dimming>
-            <dim_level>0</dim_level>
-            <falloff_type>0</falloff_type>
-            <index_of_refraction>1.5</index_of_refraction>
-            <opacity_type>0</opacity_type>
-            <reflection_level>3</reflection_level>
-            <wire_size>1</wire_size>
-            <wire_units>0</wire_units>
-          </extended_shader>
-          <shader>
-            <ambient_diffuse_lock>1</ambient_diffuse_lock>
-            <ambient_diffuse_texture_lock>1</ambient_diffuse_texture_lock>
-            <diffuse_specular_lock>0</diffuse_specular_lock>
-            <soften>0.1</soften>
-            <use_self_illum_color>0</use_self_illum_color>
-          </shader>
-        </technique>
-      </extra>
-    </effect>
     <effect id="icomLCD_2">
       <profile_COMMON>
         <technique sid="common">
@@ -3420,9 +3347,6 @@
     <material id="icomLCD_1-material" name="icomLCD">
       <instance_effect url="#icomLCD_1"/>
     </material>
-    <material id="MultiMat_2__ic40Channel_-material" name="MultiMat_2__ic40Channel_">
-      <instance_effect url="#MultiMat_2__ic40Channel_"/>
-    </material>
     <material id="icomLCD_2-material" name="icomLCD">
       <instance_effect url="#icomLCD_2"/>
     </material>
@@ -4961,14 +4885,8 @@
           <instance_geometry url="#geom-ic40Channel">
             <bind_material>
               <technique_common>
-                <instance_material symbol="icomKnobBlack_1" target="#MultiMat_2__ic40Channel_-material">
-                  <bind_vertex_input semantic="CHANNEL1" input_semantic="TEXCOORD" input_set="0"/>
-                  <bind_vertex_input semantic="CHANNEL1" input_semantic="TEXCOORD" input_set="0"/>
-                </instance_material>
-                <instance_material symbol="icomWhite_1" target="#MultiMat_2__ic40Channel_-material">
-                  <bind_vertex_input semantic="CHANNEL1" input_semantic="TEXCOORD" input_set="0"/>
-                  <bind_vertex_input semantic="CHANNEL1" input_semantic="TEXCOORD" input_set="0"/>
-                </instance_material>
+                <instance_material symbol="icomKnobBlack_1" target="#icomKnobBlack-material"/>
+                <instance_material symbol="icomWhite_1" target="#icomGrey-material"/>
               </technique_common>
             </bind_material>
           </instance_geometry>


### PR DESCRIPTION
@allisoncorey Pull request for a fairly basic art model fix, for ticket #2799.

Ticket was wanting to fix a bad texture graphic file reference in the collada file, and make the channel knob match the volume knob in appearance.

Inspecting the actual file, the materials for the channel and volume knob were vastly different. Updating the channel knob to use the same material definition as the volume knob works, and produces the desired effect of having both knobs have the same material appearance.

Since the material definition with the incorrect graphic file reference was no longer in use, excising it from the collada file seemed the appropriate action. (if reverting back to different materials is desired, it is easy enough to go through the files history).
