### PR TITLE
Branch/navigation disableinputs fix

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -416,7 +416,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
                         pss[i].update(timepassed);
                 }
 
-                if ( navmode != "none" ) {
+                if ( navmode != "none" && !self.disableInputs ) {
 
                     // Move the user's camera according to their input
                     self.moveNavObject( timepassed );


### PR DESCRIPTION
@eric79 Pull request for redmine #2633.

The issue was to fix the disable inputs driver parameter with the navigation system. If it was set to true, the moveNavObject function was never getting created, so it would fail when it tried to call it each render.

I fixed it by checking to make sure the disable inputs was false, in addition to the existing check for navmode, before trying to call moveNavObject
