### PR TITLE
Update webrtc configuration to remove threejs driver dependency.

### DIFF
--- a/public/webrtc/index.vwf.config.yaml
+++ b/public/webrtc/index.vwf.config.yaml
@@ -13,7 +13,6 @@
 
 ---
 model:
-  vwf/model/threejs:
+  nodriver:
 view:
-  vwf/view/threejs: "#vwf-root"
   vwf/view/webrtc: { debug: false, videoProperties: { create: false } }


### PR DESCRIPTION
Since the webrtc application does not use threejs or webgl, it does not need to include the threejs drivers. 

@scottnc27603 Please review. 
