### PR TITLE
Branch/node.js chrome requests

### DIFF
--- a/lib/nodejs/admin.js
+++ b/lib/nodejs/admin.js
@@ -245,9 +245,8 @@ function HandleAdminConfig( request, response, parsedRequest ) {
 
 // HandleAdminChrome is a handler for dealing with the 'chrome' GET requests
 // of the admin interface.
-// This request returns the application's "chrome" HTML overlay.
-// Returns true if it properly handles a properly formed request and the config file exists, otherwise
-// returns false. 
+// This request returns the application's "chrome" HTML overlay or an empty string if non-existant.
+// Returns true if it properly handles a properly formed request, otherwise returns false. 
 function HandleAdminChrome( request, response, parsedRequest ) {
     var publicPath = parsedRequest[ 'public_path' ];
     var appName = parsedRequest[ 'application' ];
@@ -256,8 +255,10 @@ function HandleAdminChrome( request, response, parsedRequest ) {
         var filePath = fileBasePath + ".html";
         if ( helpers.IsFile( filePath ) ) {
             servehandler.File( request, response, filePath );
-            return true;
+        } else {
+            response.end( "" );
         }
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
This adds a handler to the node.js server for the new `/admin/chrome` request that comes from vwf.js (already handled in ruby server).  This request intends to pull the "chrome" html file for the application.  Without this change, apps were getting errors trying to load their html.

@mlevan and @jessmartin, would you mind looking this over?
