### PR TITLE
Create Node Server 'Logs' directory on demand.  Fixes #2828

### DIFF
--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -127,25 +127,42 @@ function OnConnection( socket ) {
 
 
         global.instances[ namespace ].state = { };
-    
-        //create or open the log for this instance
-        if(global.logLevel >= 2) {
-            var log = fs.createWriteStream( './/Logs/' + namespace.replace( /[\\\/]/g, '_' ), { 'flags': 'a' } );
+        
+        var log;
+        function generateLogFile() {
+            try {
+                if ( !fs.existsSync( './/Logs/' ) ) {
+                    fs.mkdir( './/Logs/', function ( err ) {
+                        if ( err ) {
+                            console.log ( err );
+                        } 
+                    })
+                }
+                log = fs.createWriteStream( './/Logs/' + namespace.replace( /[\\\/]/g, '_' ), { 'flags': 'a' } );
+            } catch( err ) {
+                console.log( 'Error generating Node Server Log File\n');
+            }
         }
 
         global.instances[ namespace ].Log = function ( message, level ) {
             if( global.logLevel >= level ) {
+                if ( !log ) {
+                    generateLogFile();
+                }
                 log.write( message + '\n' );
                 global.log( message + '\n' );
             }
         };
-
+        
         global.instances[ namespace ].Error = function ( message, level ) {
             var red, brown, reset;
             red   = '\u001b[31m';
             brown  = '\u001b[33m';
             reset = '\u001b[0m';
             if ( global.logLevel >= level ) {
+                if ( !log ) {
+                    generateLogFile();
+                }
                 log.write( message + '\n' );
                 global.log( red + message + reset + '\n' );
             }


### PR DESCRIPTION
This PR includes two fixes.  

1) Previously the node server log writestream was instantiated when the server log level was >=2 (hardcoded).  This has been changed to on-demand, only create the log file when needed.

2) Logging failed if the ./Logs directory did not exist.  Now the ./Logs directory is created on demand if it doesn't exist.  
