### PR TITLE
Add Node.js Server documentation 

### DIFF
--- a/public/web/docs/install.md
+++ b/public/web/docs/install.md
@@ -300,4 +300,6 @@ One option for Node.js runtime debugging is the 'node-inspector' tool.  To use t
 
  *4. In your browser go to [http://127.0.0.1:8080/debug?port=5858](http://127.0.0.1:8080/debug?port=5858) and use as you would with your typical browser tools.*
 
+ Additional configuration options can be found at [https://github.com/node-inspector/node-inspector](https://github.com/node-inspector/node-inspector)
+
 </div>


### PR DESCRIPTION
Currently added to install doc for Installation, Execution, & Debugging.  Run 'bundle exec rake', wait for the install.html to be built, then take a look at the corresponding public/web/docs/install.html.
