### PR TITLE
Branch/node default route

### DIFF
--- a/lib/nodejs/vwf.js
+++ b/lib/nodejs/vwf.js
@@ -41,7 +41,7 @@ function HandleParsableRequest( request, response ) {
                 return true;
             }
         }
-        else if ( isRootDefault( request.url ) ) {
+        else if ( isDefaultApp( request.url ) ) {
 
             // Redirect if the url request does not include an application/file && a default 'index.vwf.yaml' exists
             serve.Redirect( request.url + helpers.GenerateInstanceID( ), response );
@@ -58,7 +58,7 @@ function HandleParsableRequest( request, response ) {
 
 // Assuming no application or file was specified in the url request, check for the existance of 
 // the default 'index.vwf.yaml' in either applicationRoot or cwd.
-function isRootDefault ( requestURL ) {
+function isDefaultApp ( requestURL ) {
 
     if ( helpers.IsFile( helpers.JoinPath( global.applicationRoot, "/index.vwf.yaml" ) )  
         || helpers.IsFile( helpers.JoinPath( process.cwd(), "/index.vwf.yaml" ) ) ) {


### PR DESCRIPTION
Resolves http://redmine.virtualworldframework.com/issues/3065 (Node Server: Can't run server from inside app directory & access the root app)

Test suite:

[ Until windows msi is completed....Specific to Windows test, expects HOME to be set to vwf working directory and VWF support files reside in homePath/.vwf. Alternatively, the vwfHome path can be hardcoded locally in node-server.js]

For each iteration, direct the url to 'localhost:3000', () = what should be served. Note, run incognito or clear browser cache each run.

cd \public\duck
node ../../node-server.js -a . (duck)
node ../../node-server.js (duck)
node ../../node-server.js -a ./images/ (404 Not found)

cd \public
node ../node-server.js -a ./duck/ (duck)
node ../node-server (web/about.html)
node ../node-server -a ./duck/images (web/about.html)
