### PR TITLE
Node.js Server parse driver-specifying url parameters.  Add casperjs tes...

### DIFF
--- a/lib/nodejs/vwf.js
+++ b/lib/nodejs/vwf.js
@@ -15,7 +15,8 @@ var parseurl = require( './parse-url' ),
 // returns false.
 function HandleParsableRequest( request, response ) {
     var parsedRequest = parseurl.Process( url.parse(request.url).pathname );
-    if ( ( request.url[ request.url.length - 1 ] != "/" ) && ( parsedRequest[ 'private_path' ] == undefined ) ) {
+
+    if ( ( request.url[ request.url.length - 1 ] != "/" ) && ( parsedRequest[ 'private_path' ] == undefined ) && ( url.parse( request.url ).search == undefined ) ) {
         if ( ( request.headers['user-agent'] ) && ( request.headers['user-agent'].indexOf("MSIE 8.0" ) > -1 ) ) {
             serve.Redirect( "/web/unsupported.html", response ); // Redirect unsupported browsers to web/docs/unsupported.html
             return true;
@@ -35,10 +36,23 @@ function HandleParsableRequest( request, response ) {
 
         if ( request.url != "/" ) {
 
+
             // Redirect if the requested url is either a specified directory or application 
             if ( helpers.IsDirectory( helpers.JoinPath( global.applicationRoot + request.url )) || parsedRequest['application'] != undefined ) {
-                serve.Redirect( request.url + helpers.GenerateInstanceID( ) +  ( url.parse(request.url, true).search.length > 0 ? "?" + url.parse(request.url, true).search : "" ), response );
-                return true;
+                
+                // Get the driver specific url parameters if applicable
+                var queryString = url.parse( request.url ).search;
+                if ( queryString == undefined ) {
+                   serve.Redirect( request.url + helpers.GenerateInstanceID( ), response );
+                   return true;
+               }
+               else {
+
+                   // Tack on the driver specific configuration parameters 
+                   serve.Redirect( helpers.JoinPath( url.parse( request.url ).pathname, helpers.GenerateInstanceID( ), queryString.replace( /\/$/, '' ) ), response );
+                   return true;
+
+               }
             }
         }
         else if ( isDefaultApp( request.url ) ) {

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -24,7 +24,7 @@ Object.keys(servers).forEach(function(server) {
     var port = servers[server];
     var serverAddress = 'http://localhost:' + port;
 
-    casper.test.begin('Testing a VWF application with the ' + server + ' server', 31, function suite(test) {
+    casper.test.begin('Testing a VWF application with the ' + server + ' server', 43, function suite(test) {
 
         //--------------//
         // Applications //
@@ -104,18 +104,13 @@ Object.keys(servers).forEach(function(server) {
 
         casper.thenOpen(serverAddress + '/duck/admin/config', function() {
             casper.echo("Loading '/duck/admin/config'", 'INFO');
-            this.wait(1000, function() {
-                test.assertHttpStatus(200, 'Retrieves the config file');
-                test.assertTextExists("VWF Duck Application", 'Parses the config file');
-
-            });
+            test.assertHttpStatus(200, 'Retrieves the config file');
+            test.assertTextExists("VWF Duck Application", 'Parses the config file');
         });
 
         casper.thenOpen(serverAddress + '/duck/', function() {
-            this.wait(1000, function() {
-                casper.echo("Loading '/duck/'", 'INFO');
-                test.assertTitle('VWF Duck Application', 'Sets the title from the config file');
-            });               
+            casper.echo("Loading '/duck/'", 'INFO');
+            test.assertTitle('VWF Duck Application', 'Sets the title from the config file');               
         });
 
         //------------//
@@ -136,6 +131,44 @@ Object.keys(servers).forEach(function(server) {
 
         // TODO: Not sure why, but this test fails. Fails to load vwf.js.
         // casper.thenOpen(serverAddress + '/test/component.vwf/0000000000000000/', loadsComponent);
+
+        //--------------------------------//
+        // Driver specific url parameters //
+        //--------------------------------//
+
+        casper.thenOpen(serverAddress + '/duck?threejs#!threejs', function() {
+            loadsApplication('/duck?threejs#!threejs');
+        });
+
+        casper.thenOpen(serverAddress + '/duck/?threejs#!threejs', function() {
+            loadsApplication('/duck/?threejs#!threejs');
+        });
+
+        casper.thenOpen(serverAddress + '/duck/0000000000000000?threejs#!threejs', function() {
+            loadsApplication('/duck/0000000000000000?threejs#!threejs');
+        });
+
+        // TODO: Not sure why, but this test fails. Fails to load vwf.js.
+        // casper.thenOpen(serverAddress + '/duck/0000000000000000/', loadsApplication);
+
+        casper.thenOpen(serverAddress + '/duck/index.vwf?threejs#!threejs', function() {
+            loadsApplication('/duck/index.vwf?threejs#!threejs');
+        });
+
+        casper.thenOpen(serverAddress + '/duck/index.vwf/?threejs#!threejs', function() {
+            loadsApplication('/duck/index.vwf/?threejs#!threejs');
+        });
+
+        casper.thenOpen(serverAddress + '/duck/index.vwf/0000000000000000?threejs#!threejs', function() {
+            loadsApplication('/duck/index.vwf/0000000000000000?threejs#!threejs');
+        });
+
+
+
+
+
+
+
 
         casper.run(function() {
             casper.echo('Finished testing the ' + server + ' server.\n', "INFO");


### PR DESCRIPTION
...ts.  Fixes #2980, #3060

Run casperjs tests or manually walk through the following;

```
    casper.thenOpen(serverAddress + '/duck?threejs#!threejs', function() {
        loadsApplication('/duck?threejs#!threejs');
    });

    casper.thenOpen(serverAddress + '/duck/?threejs#!threejs', function() {
        loadsApplication('/duck/?threejs#!threejs');
    });

    casper.thenOpen(serverAddress + '/duck/0000000000000000?threejs#!threejs', function() {
        loadsApplication('/duck/0000000000000000?threejs#!threejs');
    });

    // TODO: Not sure why, but this test fails. Fails to load vwf.js.
    // casper.thenOpen(serverAddress + '/duck/0000000000000000/', loadsApplication);

    casper.thenOpen(serverAddress + '/duck/index.vwf?threejs#!threejs', function() {
        loadsApplication('/duck/index.vwf?threejs#!threejs');
    });

    casper.thenOpen(serverAddress + '/duck/index.vwf/?threejs#!threejs', function() {
        loadsApplication('/duck/index.vwf/?threejs#!threejs');
    });

    casper.thenOpen(serverAddress + '/duck/index.vwf/0000000000000000?threejs#!threejs', function() {
        loadsApplication('/duck/index.vwf/0000000000000000?threejs#!threejs');
```
