### PR TITLE
Add Node.js reflector client disconnect notification

### DIFF
--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -255,6 +255,10 @@ function OnConnection( socket ) {
     // When a client disconnects, go ahead and remove the instance data
     socket.on( 'disconnect', function ( ) {
         
+        // Remove the disconnecting client
+        global.instances[ namespace ].clients[ socket.id ] = null;  
+        delete global.instances[ namespace ].clients[ socket.id ];
+        
         // Notify others of the disconnecting client.  Delete the child representing this client in the application's `clients.vwf` global.
         var clientMessage = { action: "deleteChild", parameters: [ "http-vwf-example-com-clients-vwf", socket.id ], time: global.instances[ namespace ].getTime( ) };
         for ( var i in global.instances[ namespace ].clients ) {
@@ -263,10 +267,6 @@ function OnConnection( socket ) {
                 client.emit ( 'message',  clientMessage );
             }
         }
-
-        // Remove the disconnecting client
-        global.instances[ namespace ].clients[ socket.id ] = null;	
-        delete global.instances[ namespace ].clients[ socket.id ];
         
         // If it's the last client, delete the data and the timer
         if ( Object.keys( global.instances[ namespace ].clients ).length == 0 ) {


### PR DESCRIPTION
This fix sends an event to all clients letting them know when a client has disconnected.  There is some additional logic in the Ruby server 'onDisconnect' which may be applicable to the Node reflector.

To test:

Open the browser debug console, <ctrl> <shift> j
Execute the test/clientNotification test (e.g. http://localhost:3000/test/clientNotification/)  
Note the logged msg in the browser console, "vwf.view.document: Client Joined:  http-vwf-example-com-clients-vwf:....."
Open up another browser/tab pointing to the same application instance.
Note the 2nd "Client Joined" msg in the browser console
Now close the 2nd (latest) application instance (browser/tab window)
Note the logged msg in the browser console, "vwf.view.document: Client Left:  http-vwf-example-com-clients-vwf:..."

This last message indicates that a disconnect notification was distributed & received properly. 
