### PR TITLE
Fixes issues with default browser, and fixes relative path issues. 

### DIFF
--- a/support/build/Scripts/build_windows_installer.nsi
+++ b/support/build/Scripts/build_windows_installer.nsi
@@ -1,3 +1,5 @@
+# Code Section comes from NSIS Wiki: http://nsis.sourceforge.net/Open_link_in_new_browser_window
+
 Function openLinkNewWindow
   Push $3
   Exch


### PR DESCRIPTION
New Windows Installer is available on the website download.virtualworldframework.com that should now open a users default browser after install.
