### PR TITLE
Branch/path hotfix

### DIFF
--- a/node_vwf.js
+++ b/node_vwf.js
@@ -76,7 +76,7 @@ function parseVWFPath () {
         return process.cwd();
     } else if ( fs.existsSync( path.join( vwfHome, "support/client/lib" ) ) ) {
         return vwfHome;
-    } else if  ( process.env.VWF_DIR && ( fs.existsSync( path.join( process.env.VWF_DIR, "support/client/lib" ) ) ) ) {
+    } else if ( process.env.VWF_DIR && fs.existsSync( path.join( process.env.VWF_DIR, "support/client/lib" ) ) ) {
         return process.env.VWF_DIR;
     } else {
         consoleError( "Could not find VWF support files." );


### PR DESCRIPTION
Fixes path ordering and variable detection in node_vwf that were causing path join failures for Mac/Linux operating systems.  VWF_DIR is used in Windows environments only.
