### PR TITLE
Add /r flag to RMDir to fully remove node-modules folder

### DIFF
--- a/support/build/Scripts/build_windows_installer.nsi
+++ b/support/build/Scripts/build_windows_installer.nsi
@@ -175,7 +175,8 @@ Section uninstall
         !Include "${FILELIST}uns"
         !DelFile "${FILELIST}uns"
         Delete "$instdir\uninst.exe"
-        RMDir "$instdir"
+        
+        RMDir /r "$instdir"
         DeleteRegKey ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}"
         ${un.EnvVarUpdate} $0 "PATH" "R" "HKLM" "$INSTDIR"  ; Append the new path
         ${un.EnvVarUpdate} $0 "VWF_DIR" "R" "HKLM" "$INSTDIR"  ; Append the new path


### PR DESCRIPTION
@allisoncorey - just needed a /r in the NSIS windows install script to fully remove a directory thats not empty.
