### PR TITLE
Notify user if websocket connection is blocked

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -865,7 +865,7 @@
                 socket.on( "error", function() { 
 
                     //Overcome by compatibility.js websockets check
-                    //jQuery('body').html("<div class='vwf-err'>WebSockets connections are currently being blocked. Please check your proxy server settings.</div>"); 
+                    jQuery('body').html("<div class='vwf-err'>WebSockets connections are currently being blocked. Please check your proxy server settings.</div>"); 
 
                 } );
 


### PR DESCRIPTION
Well, after a bit of work I stumbled across something that had been forgotten by the collective unconscious of the team - we already had a way of notifying the user that websockets were blocked by the network.  We had just commented it out.  So, in my biggest "bang for the buck" commit, I give you websocket network failure detection ... and I did it all by deleting two characters.

@jessmartin and @MichaelVacirca could you review, please?
