### PR TITLE
Kernel utility module.

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -40,6 +40,14 @@
 
         this.configuration = undefined; // require( "vwf/configuration" ).active; // "active" updates in place and changes don't invalidate the reference  // TODO: assign here after converting vwf.js to a RequireJS module and listing "vwf/configuration" as a dependency
 
+        /// Kernel utility functions and objects.
+        /// 
+        /// @name module:vwf.utility
+        /// 
+        /// @private
+
+        this.kutility = undefined; // require( "vwf/kernel/utility" );  // TODO: assign here after converting vwf.js to a RequireJS module and listing "vwf/kernel/utility" as a dependency
+
         /// The kernel logger.
         /// 
         /// @name module:vwf.logger
@@ -222,19 +230,6 @@
 
         var components = this.private.components = {}; // maps component node ID => component specification
 
-        /// The proto-prototype of all nodes is "node", identified by this URI. This type is
-        /// intrinsic to the system and nothing is loaded from the URI.
-        /// 
-        /// @name module:vwf~nodeTypeURI
-
-        var nodeTypeURI = "http://vwf.example.com/node.vwf";
-
-        /// The "node" component descriptor.
-        /// 
-        /// @name module:vwf~nodeTypeDescriptor
-
-        var nodeTypeDescriptor = { extends: null };  // TODO: detect nodeTypeDescriptor in createChild() a different way and remove this explicit null prototype
-
         /// This is the connection to the reflector. In this sample implementation, "socket" is a
         /// socket.io client that communicates over a channel provided by the server hosting the
         /// client documents.
@@ -344,6 +339,7 @@
                 { library: "vwf/view/touch", active: false },
                 { library: "vwf/view/cesium", active: false },
                 { library: "vwf/view/mil-sym", active: false },
+                { library: "vwf/kernel/utility", active: true },
                 { library: "vwf/utility", active: true },
                 { library: "vwf/model/glge/glge-compiled", active: false },
                 { library: "vwf/model/threejs/three", active: false },
@@ -543,6 +539,10 @@
             // provide additional settings when we connect.
 
             this.configuration = require( "vwf/configuration" ).active; // "active" updates in place and changes don't invalidate the reference
+
+            // Load the kernel utilities.
+
+            this.kutility = require( "vwf/kernel/utility" );
 
             // Create the logger.
 
@@ -1796,7 +1796,7 @@
 
                 if ( prototypeID === undefined ) {
                     nodeComponent.extends = null;
-                } else if ( prototypeID !== nodeTypeURI ) {
+                } else if ( prototypeID !== this.kutility.nodeTypeURI ) {
                     nodeComponent.extends = this.getNode( prototypeID );  // TODO: move to vwf/model/object and get from intrinsics
                 }
 
@@ -2046,7 +2046,7 @@ if ( useLegacyID ) {  // TODO: fix static ID references and remove
                 childIndex = childURI;
             } else {  // descendant: parent id + next from parent's sequence
 if ( useLegacyID ) {  // TODO: fix static ID references and remove
-    childID = ( childComponent.extends || nodeTypeURI ) + "." + childName;  // TODO: fix static ID references and remove
+    childID = ( childComponent.extends || this.kutility.nodeTypeURI ) + "." + childName;  // TODO: fix static ID references and remove
     childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );  // TODO: fix static ID references and remove
     childIndex = this.children( nodeID ).length;
 } else {    
@@ -2144,7 +2144,7 @@ if ( useLegacyID ) {  // TODO: fix static ID references and remove
                             // Create or find the prototype and save the ID in childPrototypeID.
 
                             if ( childComponent.extends !== null ) {  // TODO: any way to prevent node loading node as a prototype without having an explicit null prototype attribute in node?
-                                vwf.createNode( childComponent.extends || nodeTypeURI, function( prototypeID ) /* async */ {
+                                vwf.createNode( childComponent.extends || vwf.kutility.nodeTypeURI, function( prototypeID ) /* async */ {
                                     childPrototypeID = prototypeID;
 
 // TODO: the GLGE driver doesn't handle source/type or properties in prototypes properly; as a work-around pull those up into the component when not already defined
@@ -3124,7 +3124,7 @@ if ( ! childComponent.source ) {
 
                         if ( prototypeIndex < prototypeArray.length - 1 ) {
                             propertyValue = this.getProperty( prototypeID, propertyName, true ); // behavior node only, not its prototypes
-                        } else if ( prototypeID !== nodeTypeURI ) {
+                        } else if ( prototypeID !== this.kutility.nodeTypeURI ) {
                             propertyValue = this.getProperty( prototypeID, propertyName ); // prototype node, recursively
                         }
 
@@ -3898,9 +3898,9 @@ if ( ! childComponent.source ) {
 
         var loadComponent = function( nodeURI, callback_async /* ( nodeDescriptor ) */ ) {  // TODO: turn this into a generic xhr loader exposed as a kernel function?
 
-            if ( nodeURI == nodeTypeURI ) {
+            if ( nodeURI == vwf.kutility.nodeTypeURI ) {
 
-                callback_async( nodeTypeDescriptor );
+                callback_async( vwf.kutility.nodeTypeDescriptor );
 
             } else if ( nodeURI.match( RegExp( "^data:application/json;base64," ) ) ) {
 

--- a/support/client/lib/vwf/kernel/utility.js
+++ b/support/client/lib/vwf/kernel/utility.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Copyright 2014 United States Government, as represented by the Secretary of Defense, Under
+// Secretary of Defense (Personnel & Readiness).
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+/// Kernel utility functions and objects.
+/// 
+/// @module vwf/kernel/utility
+
+define( [ "module" ], function( module ) {
+
+    var exports = {
+
+        /// ID of the pseudo node that appears as the parent of the simulation's global nodes.
+        /// 
+        /// @field
+
+        globalRootID: 0,
+
+        /// The URI of the VWF proto-prototype node `node.vwf`. `nodeTypeDescriptor` contains the
+        /// descriptor associated with this URI.
+        /// 
+        /// @field
+
+        nodeTypeURI: "http://vwf.example.com/node.vwf",
+
+        /// The component descriptor of the VWF proto-prototype node `node.vwf`.
+        /// 
+        /// @field
+
+        nodeTypeDescriptor: { extends: null },  // TODO: detect nodeTypeDescriptor in createChild() a different way and remove this explicit null prototype
+
+    };
+
+    // Return the module.
+
+    return exports;
+
+} );

--- a/support/client/test/behaviors.html
+++ b/support/client/test/behaviors.html
@@ -40,6 +40,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/dispatch.html
+++ b/support/client/test/dispatch.html
@@ -41,6 +41,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/drivers.html
+++ b/support/client/test/drivers.html
@@ -45,6 +45,7 @@
         "vwf/kernel/view", // explicitly loaded until vwf can load its dependencies
         "vwf/view/test",
         "vwf/view/glge",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/events.html
+++ b/support/client/test/events.html
@@ -41,6 +41,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/future.html
+++ b/support/client/test/future.html
@@ -42,6 +42,7 @@
         "vwf/model/stage/log",
         "vwf/kernel/view",
         "vwf/view/document",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/inheritance.html
+++ b/support/client/test/inheritance.html
@@ -44,6 +44,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/methods.html
+++ b/support/client/test/methods.html
@@ -41,6 +41,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/miscellaneous.html
+++ b/support/client/test/miscellaneous.html
@@ -44,6 +44,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/node.html
+++ b/support/client/test/node.html
@@ -42,6 +42,7 @@
         "vwf/model/stage/log",
         "vwf/kernel/view",
         "vwf/view/document",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/properties.html
+++ b/support/client/test/properties.html
@@ -41,6 +41,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/replication.html
+++ b/support/client/test/replication.html
@@ -42,6 +42,7 @@
         "vwf/model/stage/log",
         "vwf/kernel/view",
         "vwf/view/document",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 

--- a/support/client/test/scripts.html
+++ b/support/client/test/scripts.html
@@ -44,6 +44,7 @@
         "vwf/model/object",
         "vwf/model/stage/log",
         "vwf/kernel/view",
+        "vwf/kernel/utility",
         "vwf/utility",
         "logger",
 


### PR DESCRIPTION
Add a `kernel/utility.js` module to eventually hold internal kernel utilities and utilities that drivers may need when interacting with the kernel. This is a predecessor to `branch/node-references`, which adds functions for mapping between nodeIDs and kernel node references.

@eric79, please review.
