### PR TITLE
Node references

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -1803,7 +1803,7 @@
 
                 if ( prototypeID === undefined ) {
                     nodeComponent.extends = null;
-                } else if ( prototypeID !== this.kutility.nodeTypeURI ) {
+                } else if ( prototypeID !== this.kutility.protoNodeURI ) {
                     nodeComponent.extends = this.getNode( prototypeID );  // TODO: move to vwf/model/object and get from intrinsics
                 }
 
@@ -2067,7 +2067,7 @@ if ( useLegacyID ) {  // TODO: fix static ID references and remove
                 childIndex = childURI;
             } else {  // descendant: parent id + next from parent's sequence
 if ( useLegacyID ) {  // TODO: fix static ID references and remove
-    childID = ( childComponent.extends || this.kutility.nodeTypeURI ) + "." + childName;  // TODO: fix static ID references and remove
+    childID = ( childComponent.extends || this.kutility.protoNodeURI ) + "." + childName;  // TODO: fix static ID references and remove
     childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );  // TODO: fix static ID references and remove
     childIndex = this.children( nodeID ).length;
 } else {    
@@ -2165,7 +2165,7 @@ if ( useLegacyID ) {  // TODO: fix static ID references and remove
                             // Create or find the prototype and save the ID in childPrototypeID.
 
                             if ( childComponent.extends !== null ) {  // TODO: any way to prevent node loading node as a prototype without having an explicit null prototype attribute in node?
-                                vwf.createNode( childComponent.extends || vwf.kutility.nodeTypeURI, function( prototypeID ) /* async */ {
+                                vwf.createNode( childComponent.extends || vwf.kutility.protoNodeURI, function( prototypeID ) /* async */ {
                                     childPrototypeID = prototypeID;
 
 // TODO: the GLGE driver doesn't handle source/type or properties in prototypes properly; as a work-around pull those up into the component when not already defined
@@ -3145,7 +3145,7 @@ if ( ! childComponent.source ) {
 
                         if ( prototypeIndex < prototypeArray.length - 1 ) {
                             propertyValue = this.getProperty( prototypeID, propertyName, true ); // behavior node only, not its prototypes
-                        } else if ( prototypeID !== this.kutility.nodeTypeURI ) {
+                        } else if ( prototypeID !== this.kutility.protoNodeURI ) {
                             propertyValue = this.getProperty( prototypeID, propertyName ); // prototype node, recursively
                         }
 
@@ -3919,9 +3919,9 @@ if ( ! childComponent.source ) {
 
         var loadComponent = function( nodeURI, callback_async /* ( nodeDescriptor ) */ ) {  // TODO: turn this into a generic xhr loader exposed as a kernel function?
 
-            if ( nodeURI == vwf.kutility.nodeTypeURI ) {
+            if ( nodeURI == vwf.kutility.protoNodeURI ) {
 
-                callback_async( vwf.kutility.nodeTypeDescriptor );
+                callback_async( vwf.kutility.protoNodeDescriptor );
 
             } else if ( nodeURI.match( RegExp( "^data:application/json;base64," ) ) ) {
 

--- a/support/client/lib/vwf/kernel/utility.js
+++ b/support/client/lib/vwf/kernel/utility.js
@@ -27,18 +27,18 @@ define( [ "module" ], function( module ) {
 
         globalRootID: 0,
 
-        /// The URI of the VWF proto-prototype node `node.vwf`. `nodeTypeDescriptor` contains the
+        /// The URI of the VWF proto-prototype node `node.vwf`. `protoNodeDescriptor` contains the
         /// descriptor associated with this URI.
         /// 
         /// @field
 
-        nodeTypeURI: "http://vwf.example.com/node.vwf",
+        protoNodeURI: "http://vwf.example.com/node.vwf",
 
         /// The component descriptor of the VWF proto-prototype node `node.vwf`.
         /// 
         /// @field
 
-        nodeTypeDescriptor: { extends: null },  // TODO: detect nodeTypeDescriptor in createChild() a different way and remove this explicit null prototype
+        protoNodeDescriptor: { extends: null },  // TODO: detect protoNodeDescriptor in createChild() a different way and remove this explicit null prototype
 
         /// Wrap `nodeID` in an object in such a way that it can stand in for a node reference
         /// without being confused with any other application value. The returned object will

--- a/support/client/lib/vwf/model/javascript.js
+++ b/support/client/lib/vwf/model/javascript.js
@@ -1223,9 +1223,9 @@ future.hasOwnProperty( eventName ) ||  // TODO: calculate so that properties tak
 
         if ( typeof value === "object" && value !== null ) {
 
-            var nodeNode = this.nodes[ kutility.nodeTypeURI ];  // our proxy for the node.vwf prototype
+            var protoNodeNode = this.nodes[ kutility.protoNodeURI ];  // our proxy for the node.vwf prototype
 
-            if ( nodeNode && ( nodeNode.isPrototypeOf( value ) || value === nodeNode ) ) {
+            if ( protoNodeNode && ( protoNodeNode.isPrototypeOf( value ) || value === protoNodeNode ) ) {
                 return kutility.nodeReference( value.id );
             } else {
                 return value;

--- a/support/client/test/behaviors.html
+++ b/support/client/test/behaviors.html
@@ -241,21 +241,21 @@
                 derivedID, derivedBaseBehaviorID, derivedBaseBehaviorOtherBehaviorID, derivedDerivedBehaviorID,
                 baseID, derivedBehaviorID, baseBehaviorID, otherBehaviorID, cleanup ) {
 
-              var nodeTypeURI = "http://vwf.example.com/node.vwf";  // TODO: get from kernel/utility.js once it's available
+              var protoNodeURI = require( "vwf/kernel/utility" ).protoNodeURI;
 
               // Base node.
 
-              equal( vwf.prototype( baseID ), nodeTypeURI, "base prototype" );
+              equal( vwf.prototype( baseID ), protoNodeURI, "base prototype" );
               deepEqual( vwf.behaviors( baseID ), [], "base behaviors" );
-              deepEqual( vwf.prototypes( baseID ), [ nodeTypeURI ], "base prototypes" );
-              deepEqual( vwf.prototypes( baseID, true ), [ nodeTypeURI ], "base prototypes with behaviors" );
+              deepEqual( vwf.prototypes( baseID ), [ protoNodeURI ], "base prototypes" );
+              deepEqual( vwf.prototypes( baseID, true ), [ protoNodeURI ], "base prototypes with behaviors" );
 
               // Derived node without behaviors.
 
               equal( vwf.prototype( derivedID ), baseID, "derived prototype" );
               deepEqual( vwf.behaviors( derivedID ), [], "derived behaviors" );
-              deepEqual( vwf.prototypes( derivedID ), [ baseID, nodeTypeURI ], "derived prototypes" );
-              deepEqual( vwf.prototypes( derivedID, true ), [ baseID, nodeTypeURI ], "derived prototypes with behaviors" );
+              deepEqual( vwf.prototypes( derivedID ), [ baseID, protoNodeURI ], "derived prototypes" );
+              deepEqual( vwf.prototypes( derivedID, true ), [ baseID, protoNodeURI ], "derived prototypes with behaviors" );
 
               // Derived node with two behaviors. A node's behaviors should be inserted before its
               // prototype, and the behaviors should be in descending order of inheritance.
@@ -265,9 +265,9 @@
               deepEqual( vwf.behaviors( derivedBaseBehaviorOtherBehaviorID ),
                 [ otherBehaviorID, baseBehaviorID ], "derived-with-behaviors behaviors" );
               deepEqual( vwf.prototypes( derivedBaseBehaviorOtherBehaviorID ),
-                [ baseID, nodeTypeURI ], "derived-with-behaviors prototypes" );
+                [ baseID, protoNodeURI ], "derived-with-behaviors prototypes" );
               deepEqual( vwf.prototypes( derivedBaseBehaviorOtherBehaviorID, true ),
-                [ baseBehaviorID, otherBehaviorID, baseID, nodeTypeURI ], "derived-with-behaviors prototypes with behaviors" );
+                [ baseBehaviorID, otherBehaviorID, baseID, protoNodeURI ], "derived-with-behaviors prototypes with behaviors" );
 
               // Node with a behavior derived from a derived node with a behavior. Each node's
               // behaviors should be inserted before their prototypes.
@@ -277,9 +277,9 @@
               deepEqual( vwf.behaviors( doubleDerivedOtherBehaviorDerivedBaseBehaviorID ),
                 [ otherBehaviorID ], "double-derived behaviors" );
               deepEqual( vwf.prototypes( doubleDerivedOtherBehaviorDerivedBaseBehaviorID ),
-                [ derivedBaseBehaviorID, baseID, nodeTypeURI ], "double-derived prototypes" );
+                [ derivedBaseBehaviorID, baseID, protoNodeURI ], "double-derived prototypes" );
               deepEqual( vwf.prototypes( doubleDerivedOtherBehaviorDerivedBaseBehaviorID, true ),
-                [ otherBehaviorID, derivedBaseBehaviorID, baseBehaviorID, baseID, nodeTypeURI ],
+                [ otherBehaviorID, derivedBaseBehaviorID, baseBehaviorID, baseID, protoNodeURI ],
                 "double-derived prototypes with behaviors" );
 
               cleanup();


### PR DESCRIPTION
Allow properties to directly reference nodes. Previously, properties couldn't contain a node reference in a way that was meaningful outside of `model/javascript` or that would survive replication.

This is a predecessor to `branch/collection-events`, which needs to send a node reference in `node.children.added` and `node.children.removed`.

@eric79, please review. @allisoncorey, @scottnc27603, @jessmartin, you also may be interested.
