### PR TITLE
Allow user to specify name of shared user object (did default to "camera")

### DIFF
--- a/support/proxy/vwf.example.com/scene.vwf.yaml
+++ b/support/proxy/vwf.example.com/scene.vwf.yaml
@@ -88,6 +88,7 @@ properties:
     extends: http://vwf.example.com/camera.vwf
     implements: [ "http://vwf.example.com/navigable.vwf" ]
     properties:
+      name: camera
       navmode: fly
 
   ## Boolean determines whether the users own avatars should be visible to themselves
@@ -170,7 +171,7 @@ scripts:
     this.initialize = function() {
       if ( this.usersShareView ) {
 
-        this.children.create( "camera", this.userObject, function( child ) {
+        this.children.create( this.userObject.properties.name, this.userObject, function( child ) {
           scene.initializeActiveCamera( child.id );
         } );
 


### PR DESCRIPTION
@BrettASwift or @scottnc27603 would you mind reviewing?
