### PR TITLE
Temporarily remove link in README.md to Windows installer (until PATH is...

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This command may be re-run to upgrade the installation to the latest version of 
 
 <!-- - Download and run the [VWF Windows Installer](http://download.virtualworldframework.com/files/VWF_Windows_Install.exe). -->
 
-- The Windows Installer has temporarily been taken down for maintenance.  In the mean time, to install on Windows, do what the next sentence says:
+- The Windows Installer has temporarily been taken down for maintenance.  In the mean time, follow our [Installation Instructions](http://virtual.wf/documentation.html#install).
 
 For more complex installations, such as working on VWF core, please see our [Installation Instructions](http://virtual.wf/documentation.html#install).
 


### PR DESCRIPTION
... fixed)

Right now, some users are finding that the 0.6.22 Windows installer overwrites their PATH variable.  We will link back up to the installer when we are sure that it is fixed.

@jessmartin or @allisoncorey or @davideaster, would you mind reviewing?
