### PR TITLE
Turn off view interpolation on the camera node (previously was only navObject)

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -548,7 +548,9 @@ define( [ "module", "vwf/view", "vwf/utility", "hammer", "jquery" ], function( m
             if(last && now && !matCmp(last,now,.0001) ) {             
                 var interp = matrixLerp(last, now, step || 0);
                 
-                if(!navObject || nodeID != navObject.ID) {             
+                var objectIsControlledByUser = ( ( navObject && ( nodeID === navObject.ID ) ) || 
+                                                 ( cameraNode && ( nodeID === cameraNode.ID ) ) );
+                if ( !objectIsControlledByUser ) {             
                     setTransform(nodeID, interp);    
                     self.nodes[nodeID].needTransformRestore = true;
                 }


### PR DESCRIPTION
When a user controls the navObject in walk mode, the yaw is applied to the navObject and the pitch is applied to the camera.  Therefore, both objects (if they are different objects) are under user control and the latency avoidance applied to objects under user control conflicts with view interpolation, so we must turn it off.

@BrettASwift or @rchadwic would you mind reviewing?
