### PR TITLE
Allow app developer to disable creation of default nav object

### DIFF
--- a/support/proxy/vwf.example.com/scene.vwf.yaml
+++ b/support/proxy/vwf.example.com/scene.vwf.yaml
@@ -168,7 +168,7 @@ scripts:
     this.activeCameraComp = undefined;
 
     this.initialize = function() {
-      if ( this.usersShareView ) {
+      if ( this.usersShareView && this.userObject ) {
         var scene = this;
         this.children.create( this.userObject.properties.name, this.userObject, function( child ) {
           scene.initializeActiveCamera( child );


### PR DESCRIPTION
They need only set the scene's userObject property to null

@BrettASwift or @scottnc27603 would you mind reviewing?
