### PR TITLE
When this.worldTransform is falsy, default to a Mat4 instead of a Vec3

### DIFF
--- a/support/proxy/vwf.example.com/node3/animation.vwf.yaml
+++ b/support/proxy/vwf.example.com/node3/animation.vwf.yaml
@@ -369,7 +369,7 @@ methods:
       - transform
       - duration
     body: |
-      var startWorldTransform = this.worldTransform || goog.vec.Vec3.create();
+      var startWorldTransform = this.worldTransform || goog.vec.Mat4.create();
       var deltaTransform = this.transformFromValue( transform );
       // Left multiply by the delta
       var stopWorldTransform = goog.vec.Mat4.multMat( deltaTransform, startWorldTransform, 


### PR DESCRIPTION
When this.worldTransform is falsy, default to a Mat4 instead of a Vec3

@BrettASwift would you mind reviewing?
