### PR TITLE
Branch/fix animation time conflict

### DIFF
--- a/support/proxy/vwf.example.com/blockly/controller.vwf.yaml
+++ b/support/proxy/vwf.example.com/blockly/controller.vwf.yaml
@@ -41,7 +41,7 @@ events:
   blocklyVisibleChanged:
 scripts:
 - |
-    var defaultAnimationDuration = 1;
+    this.defaultAnimationDuration = 1;
     
     this.getWorldXYVector = function( x, y ) {
 
@@ -70,46 +70,46 @@ scripts:
         case "translateBy":
           //dir = this.getWorldXYVector( 0, -1 );
           //speed = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.forwardSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           //this.translateBy( [ dir[ 0 ] * speed, dir[ 1 ] * speed, 0 ], t );
           this.translateBy( value, t );
           break;
 
         case "translateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.translateBy( value, t );
           break;
 
         case "rotateBy":
           //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.rotateBy( value, t );
           break;
 
         case "rotateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.rotateTo( value, t );
           break;
 
         case "quaterniateBy":
           //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.quaterniateBy( value, t );
           break;
 
         case "quaterniateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.quaterniateTo( value, t );
           break;
 
         case "scaleBy":
           //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.scaleBy( value, t );
           break;
 
         case "scaleTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : defaultAnimationDuration;
+          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
           this.scaleTo( value, t );
           break;
 


### PR DESCRIPTION
animationTime was conflicting with the animation.vwf animationTime property. This was causing the first animation to be set to its end time, making the first blockly block appear to not execute on the blockly node.

Replaced it with a private variable since setting this property to anything other than blockly's execution frequency could cause the node animations to get out of sync.

@eric79 @scottnc27603 @kadst43 Please review.
