### PR TITLE
Blockly refactor

### DIFF
--- a/support/client/lib/vwf/model/blockly.js
+++ b/support/client/lib/vwf/model/blockly.js
@@ -108,32 +108,6 @@ define( [ "module", "vwf/model",
                 return;                
             }
 
-            var protos = getPrototypes( childExtendsID );
-            var createNode = function() {
-                return {
-                    "parentID": nodeID,
-                    "ID": childID,
-                    "extendsID": childExtendsID,
-                    "implementsIDs": childImplementsIDs,
-                    "source": childSource,
-                    "type": childType,
-                    "name": childName,
-                    "loadComplete": callback,
-                    "prototypes": protos,
-                    "blocks": "<xml></xml>",
-                    "code": undefined,
-                    "codeLine": -1,
-                    "lastLineExeTime": undefined,
-                    "timeBetweenLines": 1,
-                    "interpreter": undefined,
-                    "interpreterStatus": ""
-                };
-            }; 
-
-            var node;
-            if ( isBlockly3Node( childID ) ) {
-                this.state.nodes[ childID ] = node = createNode();
-            }
 
         },
 
@@ -143,6 +117,30 @@ define( [ "module", "vwf/model",
             if ( this.debug.initializing ) {
                 this.logger.infox( "initializingNode", nodeID, childID, childExtendsID, childImplementsIDs, childSource, childType, childName );
             } 
+
+            var node;
+            var createNode = function() {
+                return {
+                    "parentID": nodeID,
+                    "ID": childID,
+                    "extendsID": childExtendsID,
+                    "implementsIDs": childImplementsIDs,
+                    "source": childSource,
+                    "type": childType,
+                    "name": childName,
+                    
+                    "blocks": "<xml></xml>",
+                    "code": undefined,
+                    "codeLine": -1,
+                    "lastLineExeTime": undefined,
+                    "timeBetweenLines": 1,
+                    "interpreter": undefined,
+                    "interpreterStatus": ""
+                };
+            }; 
+            if ( isBlockly3Node( childID ) ) {
+                this.state.nodes[ childID ] = node = createNode();
+            }
         },
 
         deletingNode: function( nodeID ) {
@@ -251,15 +249,15 @@ define( [ "module", "vwf/model",
 
                 switch ( propertyName ) {
                     
-                    case  "blockCode":
+                    case  "blockly_code":
                         value = node.code = propertyValue;
                         break;
                     
-                    case "blockXml":
+                    case "blockly_xml":
                         value = node.blocks = propertyValue;
                         break;
 
-                    case "executing":
+                    case "blockly_executing":
                         var exe = Boolean( propertyValue );
                         if ( exe ) {
                             if ( this.state.executingBlocks === undefined ) {
@@ -303,7 +301,7 @@ define( [ "module", "vwf/model",
             if ( nodeID == this.kernel.application() ) {
                 
                 // this is not quite right, need to check to see if 
-                // all of the blocks are executing here
+                // all of the blocks are blockly_executing here
                 if ( propertyName === "executingAll" ) {
                     value = ( this.state.executingBlocks !== undefined ); 
                 }
@@ -311,15 +309,15 @@ define( [ "module", "vwf/model",
             } else if ( node !== undefined ){
                 switch ( propertyName ) {
                     
-                    case "executing":
+                    case "blockly_executing":
                         value = ( this.state.executingBlocks && this.state.executingBlocks[ nodeID ] !== undefined );
                         break;
                     
-                    case "blockCode":
+                    case "blockly_code":
                         value = node.code;
                         break;
                     
-                    case "blockXml":
+                    case "blockly_xml":
                         value = node.blocks;
                         break;
 
@@ -341,7 +339,7 @@ define( [ "module", "vwf/model",
                 switch ( methodName ) {
                     case "stopAllExecution":
                         for ( var id in this.state.executingBlocks ) {
-                            this.settingProperty( id, 'executing', false );
+                            this.settingProperty( id, 'blockly_executing', false );
                         }
                         break;
                 }
@@ -389,10 +387,6 @@ define( [ "module", "vwf/model",
                         nextStep( blocklyNode );
 
                         this.kernel.fireEvent( nodeID, "blocklyExecuted", [ blocklyNode.interpreter.value ] ); 
-
-                        //    this.kernel.setProperty( nodeID, "executing", false );
-                        //    this.kernel.fireEvent( nodeID, "blocklyStopped", [ blocklyNode.codeLine ] );
-
                     }
                 } 
             }
@@ -450,7 +444,7 @@ define( [ "module", "vwf/model",
                         this.kernel.fireEvent( node.ID, "blocklyStarted", [ true ] );
                         blocklyNode.interpreterStatus = "started";                        
                     } else if ( node.interpreterStatus === "started" ) {
-                        this.kernel.setProperty( node.ID, "executing", false );
+                        this.kernel.setProperty( node.ID, "blockly_executing", false );
                         this.kernel.fireEvent( node.ID, "blocklyStopped", [ blocklyNode.codeLine ] );
                         blocklyNode.interpreterStatus = "finished";
                     }

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -97,16 +97,16 @@ define( [ "module", "vwf/view", "jquery" ], function( module, view, $ ) {
                         var blockCount = Blockly.mainWorkspace.getAllBlocks().length;
                         var topBlockCount = Blockly.mainWorkspace.topBlocks_.length;
                         
-                        self.kernel.setProperty( self.state.blockly.node.ID, "blockCount", blockCount );
-                        self.kernel.setProperty( self.state.blockly.node.ID, "topBlockCount", topBlockCount );
+                        self.kernel.setProperty( self.state.blockly.node.ID, "blockly_blockCount", blockCount );
+                        self.kernel.setProperty( self.state.blockly.node.ID, "blockly_topBlockCount", topBlockCount );
 
                         // the following code could be used to 
                         // replicate the blockly blocks in the current UI
                         //var xml = Blockly.Xml.workspaceToDom( Blockly.getMainWorkspace() );
                         //if ( xml ) { 
-                        //    self.kernel.setProperty( self.state.blockly.node.ID, "blockXml", Blockly.Xml.domToText( xml ) );
+                        //    self.kernel.setProperty( self.state.blockly.node.ID, "blockly_xml", Blockly.Xml.domToText( xml ) );
                         //}
-                        //self.kernel.setProperty( self.state.blockly.node.ID, "blockCode", Blockly.JavaScript.workspaceToCode() );
+                        //self.kernel.setProperty( self.state.blockly.node.ID, "blockly_code", Blockly.JavaScript.workspaceToCode() );
  
                     }
 
@@ -229,8 +229,8 @@ define( [ "module", "vwf/view", "jquery" ], function( module, view, $ ) {
         var blockCount = Blockly.mainWorkspace.getAllBlocks().length;
         var topBlockCount = Blockly.mainWorkspace.topBlocks_.length;
         
-        self.kernel.setProperty( node.ID, "blockCount", blockCount );
-        self.kernel.setProperty( node.ID, "topBlockCount", topBlockCount );      
+        self.kernel.setProperty( node.ID, "blockly_blockCount", blockCount );
+        self.kernel.setProperty( node.ID, "blockly_topBlockCount", topBlockCount );      
     }
 
     function getBlockXML( node ) {

--- a/support/proxy/vwf.example.com/blockly/controller.vwf.yaml
+++ b/support/proxy/vwf.example.com/blockly/controller.vwf.yaml
@@ -20,41 +20,50 @@
 extends:
   http://vwf.example.com/node3/animation.vwf
 properties:
-  forwardSpeed: 400
-  rotateSpeed: 30
-  executing: false
-  blockXml: "<xml></xml>"
-  blockCode:
-  topBlockCount:
+  blockly_executing: false
+  blockly_xml: "<xml></xml>"
+  blockly_code:
     set: |
-      if ( this.topBlockCount != value ) {
-        this.topBlockCount = value;
+      if ( this.blockly_code != value ) {
+        this.blockly_code = value;
+        this.blocklyCodeChanged( value );
+      }
+    value: 0
+  blockly_topBlockCount:
+    set: |
+      if ( this.blockly_topBlockCount != value ) {
+        this.blockly_topBlockCount = value;
         this.topBlockCountChanged( value );
       }
     value: 0
-  blockCount:
+  blockly_blockCount:
     set: |
-      if ( this.blockCount != value ) {
-        this.blockCount = value;
+      if ( this.blockly_blockCount != value ) {
+        this.blockly_blockCount = value;
         this.blockCountChanged( value );
       }
     value: 0
-  allowedBlocks: 20   
+  blockly_allowedBlocks:   
+    set: |
+      if ( this.blockly_allowedBlocks != value ) {
+        this.blockly_allowedBlocks = value;
+        this.allowedBlocksChanged( value );
+      }
+    value: 20
 methods:
   getWorldXYVector:
-  executeBlocklyCmd:
 events:
   blocklyStarted:
   blocklyExecuted:
   blocklyErrored:
   blocklyStopped:
-  blockCountChanged:
+  blocklyCodeChanged:
   topBlockCountChanged:
+  blockCountChanged:
+  allowedBlocksChanged:
   blocklyVisibleChanged:
 scripts:
 - |
-    this.defaultAnimationDuration = 1;
-    
     this.getWorldXYVector = function( x, y ) {
 
       var dir = goog.vec.Vec3.create();
@@ -70,64 +79,5 @@ scripts:
       goog.vec.Vec3.normalize( dir, dir ); 
       return dir;
 
-    }
-
-    this.executeBlocklyCmd = function( cmd, value, time ) {
-
-      var dir = undefined;
-      var speed, angle, t;
-
-      switch( cmd ) {
-
-        case "translateBy":
-          //dir = this.getWorldXYVector( 0, -1 );
-          //speed = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.forwardSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          //this.translateBy( [ dir[ 0 ] * speed, dir[ 1 ] * speed, 0 ], t );
-          this.translateBy( value, t );
-          break;
-
-        case "translateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.translateBy( value, t );
-          break;
-
-        case "rotateBy":
-          //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.rotateBy( value, t );
-          break;
-
-        case "rotateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.rotateTo( value, t );
-          break;
-
-        case "quaterniateBy":
-          //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.quaterniateBy( value, t );
-          break;
-
-        case "quaterniateTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.quaterniateTo( value, t );
-          break;
-
-        case "scaleBy":
-          //angle = ( magnitude && Number( magnitude ) ) ? Number( magnitude ) : this.rotateSpeed;
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.scaleBy( value, t );
-          break;
-
-        case "scaleTo":
-          t = ( time && time !== "0" ) ? parseFloat( time ) : this.defaultAnimationDuration;
-          this.scaleTo( value, t );
-          break;
-
-        default:
-          break;
-      }
-
-    }  //@ sourceURL=blockly-controller.vwf
+    } //@ sourceURL=blockly-controller.vwf
     


### PR DESCRIPTION
Refactors the roverBlockly behavior out of the project, and places all of the generic blockly functionality into the core.  These are changes that have occurred after putting the JS-Interpreter into the blockly model driver.

Issues(should be fixed on another branch):

Wonky ram calculations.  ramMax and blockly_allowedBlocks are really the same data now, so we may want to do the calculations different.  Regardless, blockly_allowedBlocks should remain in blockly/controller as many blockly applications will want to restrict the number of blocks for a given task.  I made some changes to scenario which we might want to back out, I was trying to get the initial ram calculating properly. 

I had to move a couple of the blockly changed listeners into it's own file.  Either this was a caching problem or the change was require to get those events to be called properly.

Include the 'blockly-refactor' branch from mars-game to test this branch.
