### PR TITLE
Branch/blockly auto close fix

### DIFF
--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -46,6 +46,11 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                 };
             }
 
+            this.currentProperties = {
+                "blockly_toolbox": undefined,
+                "blockly_autoClose": undefined
+            };
+
             this.options = ( options !== undefined ? options : {} );
 
             this.options.blocklyPath = options.blocklyPath ? options.blocklyPath : './blockly/';
@@ -201,6 +206,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                                 }
                             }
                         } else {
+                            this.currentProperties.blockly_toolbox = propertyValue;
                             this.logger.warnx( "Blockly not initilized unable to set the toolbox: " + propertyValue );
                         }
                         break;
@@ -214,8 +220,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                         break;
 
                     case "blockly_autoClose":
-                        if ( Blockly && Blockly.Flyout ){
-                            Blockly.Flyout.autoClose = Boolean( propertyValue );                       
+                        if ( Blockly && Blockly.Toolbox && Blockly.Toolbox.flyout_ ){
+                            Blockly.Toolbox.flyout_.autoClose = Boolean( propertyValue );                       
+                        } else {
+                            this.currentProperties.blockly_autoClose = Boolean( propertyValue );
                         }
                         break;
 
@@ -287,6 +295,14 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
     function setBlocklyUIVisibility( node, show ) {
         var div = document.getElementById( self.options.divParent ); {
             div.style.visibility = show ? 'visible' : 'hidden';
+        }
+        if ( self.currentProperties !== undefined ) {
+            for ( var prop in self.currentProperties ) {
+                if ( self.currentProperties[ prop ] !== undefined ) {
+                    self.satProperty( self.kernel.application(), prop, self.currentProperties[ prop ] );
+                }
+            }
+            self.currentProperties = undefined;
         }
         self.kernel.fireEvent( node.ID, "blocklyVisibleChanged", [ show ] );
     }


### PR DESCRIPTION
I had incorrectly set the autoClose property previously, so this fixes the property and keeps the category open during block dragging/creation
