### PR TITLE
Branch/blockly disable on exe

### DIFF
--- a/support/client/lib/vwf/model/blockly.js
+++ b/support/client/lib/vwf/model/blockly.js
@@ -419,11 +419,12 @@ define( [ "module", "vwf/model",
     }
 
     function setFlyoutEnable( enable ) {
-        debugger;
         var blocks = Blockly.Toolbox.flyout_.workspace_.getTopBlocks( false );
-        for ( var i = 0, block; block = blocks[ i ]; i++ ) {
-            block.setDisabled( !enable );
-        }    
+        if ( blocks ) {
+            for ( var i = 0; i < blocks.length; i++ ) {
+                blocks[ i ].setDisabled( !enable );
+            }    
+        }
     }
 
     function nextStep( node ) {


### PR DESCRIPTION
Disables the blocks in the current flyout.  Will work much better with the other pull request that leave the flyout open.  We should also figure out a way to disable opening the categories during execution, but I'm not sure that functionality exist in Blockly.  
