### PR TITLE
Branch/load specular level

### DIFF
--- a/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
+++ b/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
@@ -3556,7 +3556,7 @@ THREE.ColladaLoader = function () {
 
 								props[ 'emissive' ] = cot.color.getHex();
 
-							} if ( prop === 'specularLevel' ) {
+							} else if ( prop === 'specularLevel' ) {
 
 								props[ 'specular' ] = cot.color.getHex();
 


### PR DESCRIPTION
@eric79 Specular maps are being defined in a `specularLevel` node in Collada. I don't know that it can ever be just a color, but either way, it's accounted for. I think we should just get this fix checked in and if we want threejs to account for it, then maybe we just write up an issue or something and they can find their own solution.
