### PR TITLE
Make navigation overridable

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -190,11 +190,11 @@ define( [ "module", "vwf/view", "vwf/utility", "hammer", "jquery" ], function( m
             // If this is this user's navObject, pay attention to changes in navmode, translationSpeed, and 
             // rotationSpeed
             if ( navObject && ( nodeID == navObject.ID ) ) {
-                if ( propertyName == "navmode" ) { 
-                    if ( ( propertyValue == "none" ) && ( navmode != "none" ) && pointerLockImplemented ) {
+                if ( propertyName == "navmode" ) {
+                    navmode = propertyValue;
+                    if ( pointerLockImplemented && !self.appRequestsPointerLock() ) {
                         document.exitPointerLock();
                     }
-                    navmode = propertyValue;
                 } else if ( propertyName == "translationSpeed" ) {
                     translationSpeed = propertyValue;
                 } else if ( propertyName == "rotationSpeed" ) {


### PR DESCRIPTION
This is the beginning of changes that will make it easier for apps to override the default navigation modes.

This already makes it theoretically possible, though it might not be easy, and I haven't actually tried it from an app.  I have tested to make sure that it doesn't break the current functionality, though.

@scottnc27603 @BrettASwift would you mind reviewing?
