### PR TITLE
Made blockly toolbox load synchronous

### DIFF
--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -383,8 +383,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                     type: 'GET',
                     dataType: 'text',
                     timeout: 1000,
-                    error: function() {
-                        alert( 'Error loading XML document: ' + toolboxDef );
+                    async: false,
+                    error: function( jqXHR, textStatus, errorThrown ) {
+                        self.logger.errorx( "loadToolbox", 
+                            "Error loading XML document (" + textStatus + "): " + toolboxDef );
                     },
                     success: function( xml ) {
                         Blockly.updateToolbox( xml );


### PR DESCRIPTION
@kadst43 @scottnc27603 

The alert popup was coming in due to a timeout. Since we are loading so much at the beginning and the load being asynchronous by default, it was not loading in the 1 second allotted. I made the error go through the logger instead of an alert, so that it doesn't interrupt the process and cause websockets to disconnect, and made the xml load synchronous. The only issue now will be if the xml is too large. I don't anticipate that being an issue with the blockly toolbox, but we can cross that bridge if and when we come to it.
