### PR TITLE
graphtool catch eval error

### DIFF
--- a/support/client/lib/vwf/model/graphtool.js
+++ b/support/client/lib/vwf/model/graphtool.js
@@ -8,6 +8,8 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
     var DEPTH_AXES = Number.MIN_SAFE_INTEGER + 2;
     var DEPTH_OBJECTS = Number.MIN_SAFE_INTEGER + 1;
 
+    var self;
+
     return model.load( module, {
 
         // == Module Definition ====================================================================
@@ -15,6 +17,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         // -- initialize ---------------------------------------------------------------------------
 
         initialize: function() {
+            self = this;
             this.state.graphs = {};
             this.state.objects = {};
             this.state.kernel = this.kernel.kernel.kernel;
@@ -561,6 +564,10 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
     function generateLineFuction( graphScale, functionString, startValue, endValue, 
                             pointCount, color, opacity, thickness, renderTop ) {
 
+        if ( !isValidFunction( functionString ) ) {
+            return new THREE.Mesh();
+        }
+
         var geometry = new THREE.Geometry();
         var point, direction;
         var points = new Array();
@@ -928,6 +935,21 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
 
         return mat;
 
+    }
+
+    function isValidFunction( functionString ) {
+        return ( function( x, y, z ) {
+            var fn = "var x = " + x + ", y = " + y + ", z = " + z + ";\n" 
+                    + functionString + ";\n" 
+                    + "[ x, y, z ];";
+            try {
+                var ar = eval( fn );
+            } catch ( error ) {
+                self.logger.errorx( "generateLineFuction", error.stack );
+                return false;
+            }
+            return true;
+        } )();
     }
 
 } );

--- a/support/proxy/vwf.example.com/graphtool/graphlinefunction.vwf.yaml
+++ b/support/proxy/vwf.example.com/graphtool/graphlinefunction.vwf.yaml
@@ -17,7 +17,12 @@ methods:
       var x = point[0];
       var y = point[1]; 
       var z = point[2];
-      eval( this.lineFunction );
+      try {
+        eval( this.lineFunction );
+      } catch ( error ) {
+        this.logger.errorx( "evaluateLineAtPoint", error.stack );
+        return [ 0, 0, 0 ];
+      }
       point[ 0 ] = x || 0;
       point[ 1 ] = y || 0;
       point[ 2 ] = z || 0;


### PR DESCRIPTION
@kadst43 @AmbientOSX This will ensure that the graphtool driver no longer breaks permanently if the line function has a syntax error. Error messages are logged.
