### PR TITLE
Add ability to construct arguments for objects in objects for blockly

### DIFF
--- a/support/client/lib/vwf/model/blockly.js
+++ b/support/client/lib/vwf/model/blockly.js
@@ -530,16 +530,8 @@ define( [ "module", "vwf/model",
                         var parms = [];
                         for ( var j = 0; j < arguments.length; j++) {
                             if ( j >= 2 ) {
-                                if ( arguments[ j ].type === 'object' ) {
-                                    var temp = [];
-                                    if ( arguments[ j ].properties !== undefined ) {
-                                        for ( var k in arguments[ j ].properties ) {
-                                            temp.push( arguments[ j ].properties[ k ].data );
-                                        }
-                                    }
-                                    parms.push( temp );
-                                } else {
-                                    parms.push( arguments[ j ].toString() );
+                                if ( arguments[ j ].type === "object" ) {
+                                    parms.push( setArgsFromObj( arguments[ j ] ) );
                                 }
                             } else {
                                 parms.push( arguments[ j ].toString() );
@@ -554,6 +546,18 @@ define( [ "module", "vwf/model",
 
         };
         return new Interpreter( acorn, code, initFunc );
+    }
+
+    function setArgsFromObj( object ) {
+        var args = [];
+        for ( var i in object.properties ) {
+            if ( object.properties[ i ].type === "object" ) {
+                args.push( setArgsFromObj( object.properties[ i ] ) );
+            } else {
+                args.push( object.properties[ i ].data );
+            }
+        }
+        return args;
     }
 
 


### PR DESCRIPTION
This allows nested objects to be passed as arguments when setting code for blockly. Used in virtual-world-framework/mars-game#221

@BrettASwift @AmbientOSX 
