### PR TITLE
Removed double call on scroll

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -591,8 +591,7 @@ define( [ "module", "vwf/view", "vwf/utility", "hammer", "jquery" ], function( m
             }
 
             var navThreeObject = navObj.threeObject;
-            var originalTransform = goog.vec.Mat4.clone( navThreeObject.matrix.elements );
-
+            
             // wheelDelta has a value of 3 for every click
             var numClicks = Math.abs( wheelDelta / 3 );
 


### PR DESCRIPTION
Removed unused variables and removed a couple of calls that were causing the transform data of the camera to be incorrect when scrolling.

@eric79 @kadst43 @ajiraffe
