### PR TITLE
Add check for a material map before correcting any missing UV coordinate...

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -2677,8 +2677,9 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/utility/color", "jquery" ],
             GetAllLeafMeshes( asset, meshes );
 
             for( var i =0; i < meshes.length; i++ ) {
-                fixMissingUVs( meshes[i] );   
-                meshes[i].geometry.uvsNeedUpdate = true;
+                if ( meshes[i].material.map != null ) {
+                    fixMissingUVs( meshes[i] );
+                }
             }
             
             asset.updateMatrixWorld();


### PR DESCRIPTION
This pull request fixes an issue with smoothShading that arose in a new model with generic (non-textured) default materials. In VWF, there was an inconsistency in shading between adjacent polygons, causing flat sides to look rather jagged, and an overall non-smooth look. 

The function fixMissingUVs was the culprit which was added in commit 655dc93dc21c7cab5b711972abcd3acacf310002, adding initial support for multi-materials back in January 2013. 

I added a check to only correct any missing UVs if there is a material map assigned, and did some spot checking to make sure both textured and untextured models are loading correctly. 

@eric79 Can you please review?
