### PR TITLE
Improved analytic shader time handling

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -3229,7 +3229,7 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/utility/color", "jquery" ],
 			"uniform vec4 colorRange;\n"+
             "void main() {\n"+
 			//randomly offset in time
-            "   float lifetime = fract(random.x+(time))*lifespan*1.33;"+
+            "   float lifetime = mod( random.x * lifespan + time, lifespan );"+
 			//solve for position
             "   vec3 pos2 = position.xyz + velocity*lifetime + (acceleration*lifetime*lifetime)/2.0;"+ // ;
             "   vec4 mvPosition = modelViewMatrix * vec4( pos2.xyz, 1.0 );\n"+
@@ -3515,7 +3515,7 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/utility/color", "jquery" ],
 			//when updating in AnalyticShader mode, is very simple, just inform the shader of new time.
             particleSystem.updateAnalyticShader = function(time)
             {   
-                particleSystem.material.uniforms.time.value += time/3333.0;
+                particleSystem.material.uniforms.time.value += time/1000;
             
             }
             


### PR DESCRIPTION
@eric79 @davideaster @kadst43 

Simple, but effective changes to the AnalyticShader particle solver. First, I changed the `time` uniform to be in seconds, instead of it being measured in 3.333 second chunks (that made no sense to me). Second, I modified the shader so that `lifetime` is the elapsed time that the particle has existed up to the lifespan of the particle. This way, position is updated by velocity per second and acceleration per second squared. Particles now exist for the set lifetime.

All of the particle tests using the AnalyticShader will probably be much, much slower and need to be sped up.
