### PR TITLE
Changes the fs call to watchFile from watch so Cesium will load

### DIFF
--- a/lib/nodejs/file-cache.js
+++ b/lib/nodejs/file-cache.js
@@ -68,7 +68,7 @@ function _FileCache( ) {
                 global.log( 'loading into cache: ' + path, 2 );
                 if ( self.enabled == true ) {
                     self.files.push( newentry );
-                    fs.watch( path, { }, function ( event, filename ) {
+                    fs.watchFile( path, { }, function ( event, filename ) {
                         global.log( newentry.path + ' has changed on disk', 2 );
                         self.files.splice( self.files.indexOf( newentry ), 1 );
                     } );


### PR DESCRIPTION
@davideaster @eric79 
I don't know a lot about the nodejs server but a google search with the error message suggested the following change.  After updating the file, agi/cesium did load, and loaded quickly. 
