### PR TITLE
Branch/wss on 443

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -745,7 +745,8 @@
 
                 if ( isSocketIO07() ) {
 
-                    socket = io.connect( window.location.origin, options );
+                    socket = io.connect( window.location.protocol + "//" + window.location.host,
+                        options );
 
                 } else {  // Ruby Server -- only supports socket.io 0.6
 


### PR DESCRIPTION
The logic inside `io.connect` really expects it to pass it an `http` or `https` url and it will handle it from there.  We passed it `ws` and `wss` urls which it isn't 100% prepared to handle.  It mostly works, but some of the logic for choosing ports and security checks to see if the protocol is `https`.

@davideaster would you mind reviewing?
