### PR TITLE
Adds a check for the masterVolume being undefined

### DIFF
--- a/support/client/lib/vwf/model/sound.js
+++ b/support/client/lib/vwf/model/sound.js
@@ -512,7 +512,7 @@ define( [ "module", "vwf/model" ], function( module, model ) {
         },
 
         getVolume: function() {
-            return this.localVolume$ * masterVolume;
+            return this.localVolume$ * ( masterVolume !== undefined ? masterVolume : 1.0 );
         },
 
         setVolume: function( volume, fadeTime, fadeMethod ) {


### PR DESCRIPTION
@kadst43 

masterVolume was undefined, so I added a check, and then added default value.  In initialize masterVolume is set to this.masterVolume which is probably the real source of the problem.  I'm not sure how this.masterVolume would have a value at that point.  Kevin, thoughts?
