### PR TITLE
Add a property to control the animation tick rate

### DIFF
--- a/support/proxy/vwf.example.com/animation.vwf.yaml
+++ b/support/proxy/vwf.example.com/animation.vwf.yaml
@@ -305,6 +305,10 @@ properties:
         return Math.floor(this.animationTime * this.animationFPS);
       }
 
+  ## The animation update rate in ticks per second of simulation time.
+
+  animationTPS: 60
+
 methods:
 
   # Play the animation from the start.
@@ -360,8 +364,8 @@ methods:
       }
       // Schedule the next tick if still playing.
       if ( this.animationPlaying ) {
-        if ( this.animationStop$ - this.time > 1/60 ) {
-          this.in( 1/60 ).animationTick(); // next interval
+        if ( this.animationStop$ - this.time > 1 / this.animationTPS ) {
+          this.in( 1 / this.animationTPS ).animationTick(); // next interval
         } else {
           this.at( this.animationStop$ ).animationTick(); // exactly at end
         }


### PR DESCRIPTION
It may be useful to reduce the rate at which animations are calculated to reduce the CPU load when 60 fps animations are not required.

The tick rate may be set globally for all nodes that implement `animation.vwf` (after the animation component has loaded):

```
node.find( "doc('http://vwf.example.com/animation.vwf')" )[0].animationTPS = 30;
```

Or just for individual nodes:

```
node.animationTPS = 10;
```

The default animation tick rate is unchanged at 60 per second.

@eric79 @BrettASwift 
