### PR TITLE
Sound queue

### DIFF
--- a/support/client/lib/vwf/model/sound.js
+++ b/support/client/lib/vwf/model/sound.js
@@ -750,7 +750,7 @@ define( [ "module", "vwf/model" ], function( module, model ) {
         },
 
         clearQueue: function() {
-            this.queue$ = [];
+            this.queue$.length = 0;
         },
 
         hasQueuedSounds: function() {


### PR DESCRIPTION
@BrettASwift 

Some cleanup of the sound driver, fixed a different bug, but most relevant to you: made it so that
stopAllSoundInstances also clears out the sound queues (which should help with the problems
you're seeing when resetting the game).
