### PR TITLE
Make the drawing names unique per session

### DIFF
--- a/support/proxy/vwf.example.com/kinetic/drawing.js
+++ b/support/proxy/vwf.example.com/kinetic/drawing.js
@@ -212,8 +212,8 @@ this.down = function( eventData, nodeData, touch ) {
 
         var self = this;
         var selfMoniker = this.client;
-        var name = drawingMode + userState.nameIndex;
-        userState.nameIndex++;
+        var name = drawingMode + this.drawing_index;
+        this.drawing_index = this.drawing_index + 1;
         parent.children.create( name, groupDef, function( child ) {
             self.drawing_private[ selfMoniker ].drawingObject = child;
         } ); 
@@ -239,8 +239,8 @@ this.down = function( eventData, nodeData, touch ) {
 
         var self = this;
         var selfMoniker = this.client;
-        var name = drawingMode + userState.nameIndex;
-        userState.nameIndex++;
+        var name = drawingMode + this.drawing_index;
+        this.drawing_index = this.drawing_index + 1;
         parent.children.create( name, shapeDef, function( child ) {
             self.drawing_private[ selfMoniker ].drawingObject = child;
         } );

--- a/support/proxy/vwf.example.com/kinetic/drawing.vwf.yaml
+++ b/support/proxy/vwf.example.com/kinetic/drawing.vwf.yaml
@@ -3,6 +3,7 @@ extends:
   http://vwf.example.com/kinetic/stage.vwf
 properties:
   drawing_clients:
+  drawing_index: 1
 methods:
   update:
   clientWatch:


### PR DESCRIPTION
@eric79 @youngca 
I could never get chrome to load these changes, so I'm not sure they actually work, but in theory this should fix the naming issues.

vwf.getProperty( "index-vwf", "drawing_index" )

copy the line above into the console to test the drawing_index value.
