### PR TITLE
Introduce scaling to kinetic stage

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -45,8 +45,8 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             stageId = node.stage.getId();
             returnData.eventData[ 0 ].stage = [ node.stage.x(), node.stage.y() ];
             returnData.eventData[ 0 ].stageRelative = [ 
-                eventPosition.pageX - node.stage.x(),
-                eventPosition.pageY - node.stage.y()
+                ( eventPosition.pageX - node.stage.x() ) / node.stage.scaleX(),
+                ( eventPosition.pageY - node.stage.y() ) / node.stage.scaleY()
             ];    
         }
 

--- a/support/proxy/vwf.example.com/kinetic/drawing.js
+++ b/support/proxy/vwf.example.com/kinetic/drawing.js
@@ -91,10 +91,6 @@ this.setClientUIState = function( stateObj ) {
     }
 };
 
-this.getStageRelativePoint = function( e ) {
-    return [ e.page[ 0 ] - e.stage[ 0 ], e.page[ 1 ] - e.stage[ 1 ] ];
-}
-
 this.down = function( eventData, nodeData, touch ) {
 
     if ( !this.isValid( this.drawing_clients ) || !this.isValid( this.drawing_clients[ this.client ] ) ) {
@@ -179,7 +175,7 @@ this.down = function( eventData, nodeData, touch ) {
         return retObj; 
     };
 
-    var eventPointDown = this.getStageRelativePoint( eventData );
+    var eventPointDown = eventData.stageRelative;
     if ( groupExtends !== undefined ) {
 
         privateState.initialDownPoint = eventPointDown;
@@ -295,7 +291,7 @@ this.update = function( eventData, nodeData, upEvent ) {
 
     if ( this.drawing_private[ this.client ].drawingObject !== null ) {
         
-        var eventPoint = this.getStageRelativePoint( eventData );
+        var eventPoint = eventData.stageRelative;
         var userState = this.drawing_clients[ this.client ];        
         var privateState = this.drawing_private[ this.client ];
         var drawingObject = privateState.drawingObject;

--- a/support/proxy/vwf.example.com/kinetic/node.js
+++ b/support/proxy/vwf.example.com/kinetic/node.js
@@ -27,9 +27,7 @@ this.toggleVisibilty = function() {
 
 this.update = function( eventData, nodeData ) {
     if ( this.draggable && ( this.pointerIsDown || this.touching ) ) {
-        if ( this.client === this.moniker ) {
-            vwf_view.kernel.setProperty( this.id, "position", [ this.x, this.y ] );
-        }
+        this.position = eventData.stageRelative;
     }
 }
 


### PR DESCRIPTION
This accounts for scale in the eventData.stageRelative coordinates and then uses that value more broadly (so it's the only place we have to care about scale).

@scottnc27603 @youngca would you mind reviewing?
