### PR TITLE
Add a gate conditional before calling stopPropagation in case it doesn't exist

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -12,7 +12,9 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
         var returnData = { eventData: undefined, eventNodeData: undefined };
 
         if ( !propagate ) {
-            e.evt.stopPropagation();
+            // For the "dragend" event, kinetic sometimes sends us an event object that doesn't
+            // have all the expected functions and properties attached
+            e.evt.stopPropagation && e.evt.stopPropagation();
         }
 
         var eventPosition;


### PR DESCRIPTION
For the "dragend" event, kinetic sometimes sends us an event object that doesn't have all the expected functions and properties attached

@scottnc27603 @youngca would you mind reviewing?
