### PR TITLE
Remove early return from buzz.js' callingMethod function so we can pause sounds

### DIFF
--- a/support/client/lib/vwf/model/buzz.js
+++ b/support/client/lib/vwf/model/buzz.js
@@ -359,7 +359,6 @@ define( [
         // -- callingMethod --------------------------------------------------------------------------
 
         callingMethod: function( nodeID, methodName, methodParameters ) { 
-            return undefined;
 
             if ( this.debug.method ) {
                 this.logger.infox( "   G === gettingProperty ", nodeID, propertyName );


### PR DESCRIPTION
@youngca @scottnc27603 would you mind reviewing?
