### PR TITLE
Branch/mars game editor

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1709,7 +1709,7 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/utility/color", "jquery" ],
                         break;
                     case 'enableShadows':
                         if ( node.renderer ) {
-                            value = node.renderer.shadowMapEnabled = value;
+                            value = node.renderer.shadowMapEnabled;
                         }
                         break;
                     case "activeCamera":


### PR DESCRIPTION
Allow property value retrieval of 'castShadows' and 'receiveShadows' on 'THREE.Object3D' nodes. Also fixed `gettingProperty` handling of `enableShadows`.

@eric79 @kadst43 
