### PR TITLE
Switch from using stage.draw() to stage.batchDraw() to help performance.

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -435,7 +435,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
     function renderScene( stage ) {
         //window.requestAnimationFrame( renderScene( stage ) );
         if ( stage !== undefined ) {
-            stage.draw();    
+            stage.batchDraw();    
         }
     }
 


### PR DESCRIPTION
Replace tick's call to stage.draw() with stage.batchDraw().  batchDraw uses Kinetic's animation methods to render the scene in an animation frame limited to the browser's framerate rather than forcing the entire scene to draw based solely on the tick rate.  Marked performance improvements noticed on the 2D application, TDG of up to 4x framerate.

See: http://www.html5canvastutorials.com/kineticjs/html5-canvas-kineticjs-batch-draw/

@scottnc27603 @eric79 
