### PR TITLE
Correct the "mouseenter" event mapping to "pointerEnter" event.

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -159,7 +159,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                 node.kineticObj.on( "mouseenter", function( evt ) {
                     var eData = processEvent( evt, node, !TOUCH_EVENT, false );
                     //self.kernel.dispatchEvent( node.ID, 'pointerEnter', eData.eventData, eData.eventNodeData );
-                    self.kernel.fireEvent( node.ID, 'pointerOut', eData.eventData );
+                    self.kernel.fireEvent( node.ID, 'pointerEnter', eData.eventData );
                 } );
 
                 node.kineticObj.on( "mouseleave", function( evt ) {


### PR DESCRIPTION
Correct what appears to be a copy/paste error that had "mouseenter" mapping to "pointerOut".

If I want to do something when the mouse pointer first touches the node, I need to have a pointerEnter event.  Based on the commented out code above my change, it looks like it used to be correct, but a copy/paste error from the event above it was accidentally pasted instead.

@scottnc27603 @eric79 
