### PR TITLE
Allow "none" to be recognized as no echelon.

### DIFF
--- a/support/client/lib/mil-sym/cws.js
+++ b/support/client/lib/mil-sym/cws.js
@@ -4374,6 +4374,7 @@ define( function(){
                     retStr = this.region( symbolID );
                     break; 
                 case "null":
+                case "none":
                 default:
                     retStr = this._null( symbolID );
                     break; 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -264,6 +264,7 @@ define( [ "module",
                                     case "front":
                                     case "region":
                                     case "null":
+                                    case "none":
                                         if ( node.symbolID !== undefined ) {
                                             node.symbolID = cws.addEchelonToSymbolId( node.symbolID, propertyValue );
                                         }


### PR DESCRIPTION
Recognize "none" as a valid option so that it is handled as null and a warning is not thrown.

@scottnc27603 @eric79 
