### PR TITLE
Evaluate and include all valid modifiers with unit.

### DIFF
--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -335,8 +335,7 @@ define( [ "module",
                         case "quantity":
                             if ( (propertyValue === "") && unit.modifiers[ mu.C_QUANTITY ] ) {
                                 delete unit.modifiers[ mu.C_QUANTITY ];
-                            }
-                            else {
+                            } else {
                                 unit.modifiers[ mu.C_QUANTITY ] = Number( propertyValue );
                             }
                             break;
@@ -364,8 +363,7 @@ define( [ "module",
                         case "directionOfMovement":
                             if ( (propertyValue === "") && unit.modifiers[ mu.Q_DIRECTION_OF_MOVEMENT ] ) {
                                 delete unit.modifiers[ mu.Q_DIRECTION_OF_MOVEMENT ];
-                            }
-                            else {
+                            } else {
                                 unit.modifiers[ mu.Q_DIRECTION_OF_MOVEMENT ] = propertyValue;
                             }
                             break;
@@ -401,8 +399,7 @@ define( [ "module",
                         case "reinforcedReduced":
                             if ( (propertyValue === "") && unit.modifiers[ mu.F_REINFORCED_REDUCED ] ) {
                                 delete unit.modifiers[ mu.F_REINFORCED_REDUCED ];
-                            }
-                            else {
+                            } else {
                                 unit.modifiers[ mu.F_REINFORCED_REDUCED ] = propertyValue;
                             }
                             break;

--- a/support/client/lib/vwf/view/mil-sym.js
+++ b/support/client/lib/vwf/view/mil-sym.js
@@ -296,7 +296,7 @@ define( [ "module", "vwf/view", "mil-sym/cws" ], function( module, view, cws ) {
             
             // Define the list of valid modifiers
             updatedUnit[ "validModifiers" ] = [];
-            _aliasModifiers.forEach ( function(thisAliasModifier) {
+            _aliasModifiers.forEach ( function( thisAliasModifier ) {
                                             var modifier = renderer.utilities.ModifiersUnits[ thisAliasModifier.modifier ];
                                             if ( symUtil.hasModifier( updatedUnit.symbolID, 
                                                                       modifier,


### PR DESCRIPTION
This pull request addresses two issues.
1. When mil-sym.js (view) getUnitSymbol is called, each of the supported modifiers is evaluated to determine if it is valid for the particular unit symbol.  The list of valid modifiers is included with the unit symbol object, which the calling app can handle upon unit creation.
2. Handle special symbol modifiers to remove themselves from the unit symbol when their values are set to blank.  Most text-based modifiers will simply disappear from the unit symbol when set to blank. However, certain modifiers, like reinforced/reduced, direction of movement (an arrow indicating direction) and quantity do not.  They either set themselves to 0 (like quantity or direction of movement) or like reinforced/reduced appear as "null".

@scottnc27603 @eric79 
