### PR TITLE
Branch/keep stage in window

### DIFF
--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -895,15 +895,15 @@ define( [ "module",
                     
                     switch ( propertyName ) {
 
-                        case width:
+                        case "width":
                             kineticObj.setWidth( Number( propertyValue ) );
                             break;
 
-                        case height:
+                        case "height":
                             kineticObj.setHeight( Number( propertyValue ) );
                             break;
 
-                        case pixelRatio:
+                        case "pixelRatio":
                             kineticObj.setPixelRatio( parseFloat( propertyValue ) );
                             break;
                         


### PR DESCRIPTION
This branch does two things:
1. It removes the white bands we were seeing along the bottom and right of the screen
2. It allows us to set the `dragBoundFunc` of a kinetic object so we can keep the user from dragging it outside the screen.

@youngca @scottnc27603 would you mind reviewing?
