### PR TITLE
Replace broken dragend handler with our own version

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -192,6 +192,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                     mouseDown = false;
                     //self.kernel.dispatchEvent( node.ID, 'pointerUp', eData.eventData, eData.eventNodeData );
                     self.kernel.fireEvent( node.ID, 'pointerUp', eData.eventData );
+                    if ( node.kineticObj.mouseDragging ) {
+                        self.kernel.fireEvent( node.ID, 'dragEnd', eData.eventData );
+                        node.kineticObj.mouseDragging = false;
+                    }
                 } );
 
                 node.kineticObj.on( "click", function( evt ) {
@@ -240,6 +244,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                     var eData = processEvent( evt, node, undefined, false );
                     //self.kernel.dispatchEvent( node.ID, "dragStart", eData.eventData, eData.eventNodeData );
                     self.kernel.fireEvent( node.ID, 'dragStart', eData.eventData );
+                    node.kineticObj.mouseDragging = true;
                 } );
 
                 node.kineticObj.on( "dragmove", function( evt ) {
@@ -248,11 +253,13 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                     self.kernel.fireEvent( node.ID, 'dragMove', eData.eventData );
                 } );
 
-                node.kineticObj.on( "dragend", function( evt ) {
-                    var eData = processEvent( evt, node, undefined, false );
-                    //self.kernel.dispatchEvent( node.ID, "dragEnd", eData.eventData, eData.eventNodeData );
-                    self.kernel.fireEvent( node.ID, 'dragEnd', eData.eventData );
-                } );
+                // I couldn't get this to work, so instead I keep track of mouseDragging separately
+                // in dragstart and mouseup (Eric - 11/18/14)
+                // node.kineticObj.on( "dragend", function( evt ) {
+                //     var eData = processEvent( evt, node, undefined, false );
+                //     //self.kernel.dispatchEvent( node.ID, "dragEnd", eData.eventData, eData.eventNodeData );
+                //     self.kernel.fireEvent( node.ID, 'dragEnd', eData.eventData );
+                // } );
 
             }
 


### PR DESCRIPTION
I couldn't get the normal `dragend` handler working.  I don't know if something else is stealing the event or if it's a browser bug or what.  But after giving it some time and getting nowhere, I decided it was easier to create our own.

@youngca @scottnc27603 would you mind reviewing?
