### PR TITLE
Keep unit icon centered

### DIFF
--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -464,11 +464,14 @@ define( [ "module",
         if ( node !== undefined && node.nodeType === "unit" && node.symbolID !== undefined ) {
             var iconRender = armyc2.c2sd.renderer.MilStdIconRenderer;
             var img = iconRender.Render( node.symbolID, node.modifiers );
+            
             var centerPt = img.getCenterPoint();
-            value = node.image = img.toDataUrl();
             var imgSize = img.getImageBounds();
-            self.kernel.fireEvent( node.ID, "imageChanged", [ node.image, imgSize.width, imgSize.height, centerPt.x, centerPt.y ] );
-            //self.kernel.fireEvent( node.ID, "imageChanged", [ node.image, imgSize.width, imgSize.height ] );
+            var symbolBounds = img.getSymbolBounds();
+
+            value = node.image = img.toDataUrl();
+
+            self.kernel.fireEvent( node.ID, "imageRendered", [ node.image, imgSize, centerPt, symbolBounds ] );
         } 
 
         return value;       


### PR DESCRIPTION
@eric79 @youngca 
These changes go along with the bug-fix-unit-symbol-editor (which is currently up to date)branch.

symbolBounds - is not currently being used, but it is currently useful for debugging purposes if there any issues with the symbol not staying put during a rendering
