### PR TITLE
Fix replication with animations initialized with `animationTime !== 0`.

### DIFF
--- a/support/proxy/vwf.example.com/animation.vwf.yaml
+++ b/support/proxy/vwf.example.com/animation.vwf.yaml
@@ -87,9 +87,10 @@ properties:
         rate = this.animationRate;
       // Range limit the incoming value.
       value = Math.min( Math.max( this.animationStartTime, value ), this.animationStopTime );
-      // Keep paused if updating start/pause from null/null.
-      if ( this.animationStart$ == null || this.animationPause$ == 0 ) {
-        this.animationPause$ = this.time;
+      // Keep paused if updating start/pause from null/null. Use t=0 instead of `this.time` so that
+      // setting `node.animationTime` during initialization is consistent across multiple clients.
+      if ( this.animationStart$ == null ) {
+        this.animationPause$ = 0;
       }
       // Calculate the start and stop times that makes the new time work.
       this.animationStart$ =
@@ -189,8 +190,8 @@ properties:
           }
           // Recalculate the start and stop times to keep paused time unchanged, then resume.
           this.animationStart$ =
-            ( this.animationStart$ || this.time ) -
-            ( this.animationPause$ || this.time ) +
+            ( this.animationStart$ != null ? this.animationStart$ : this.time ) -
+            ( this.animationPause$ != null ? this.animationPause$ : this.time ) +
             this.time;
           this.animationStop$ =
             this.animationStart$ +


### PR DESCRIPTION
If a component implementing `animation.vwf` sets `animationTime` during initialization, the animation is set to be paused at that time, and `animationPause$` would receive a reference value based on the current simulation time. Since `animationPause$` is assigned during initialization, this isn't marked as a change.

If `animationTime` is set again after initialization, `animationStart$` and `animationStop$` receive values in relation to `animationPause$`, and they will be marked as changed. `animationPause$` hasn't changed and won't be flagged.

But since late joiners initialize with a different simulation time, they will get a different `animationPause$` value that doesn't work with the replicated `animationStart$` and `animationStop$` values.

The solution is to always take time == 0 when pausing for the first time. The absolute time doesn't matter as long as it is correctly related to the start and stop times.

We should consider holding `kernel.time()` at `0` or making it `undefined` for a component that is initializing.

A test case is to:
- Load `humvee-lesson`
- Click _Start_
- Load a second client in the same instance
- Complete the lesson up to step 3.1
- Click the gear shift to complete step 3.1
- Verify that the shift level moved to the correct position in the second client and that the second client advanced to step 3.2

@eric79 @scottnc27603 @allisoncorey, any comments?
