### PR TITLE
Detect and log load errors

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -4679,6 +4679,7 @@ if ( ! childComponent.source ) {
                     },
 
                     error: function( xhr, status, error ) /* async */ {
+                        vwf.logger.warnx( "loadComponent", "error loading", nodeURI + ":", error );
                         errback_async( error );
                         queue.resume( "after loading " + nodeURI ); // resume the queue; may invoke dispatch(), so call last before returning to the host
                     },
@@ -4719,6 +4720,7 @@ if ( ! childComponent.source ) {
                     },
 
                     error: function( xhr, status, error ) /* async */ {
+                        vwf.logger.warnx( "loadScript", "error loading", scriptURI + ":", error );
                         errback_async( error );
                         queue.resume( "after loading " + scriptURI ); // resume the queue; may invoke dispatch(), so call last before returning to the host
                     },

--- a/support/client/lib/vwf/configuration.js
+++ b/support/client/lib/vwf/configuration.js
@@ -174,11 +174,13 @@ define( function() {
             "randomize-ids": false,               // randomize IDs to discourage assumptions about ID allocation
             "humanize-ids": false,                // append recognizable strings to node IDs
             "preserve-script-closures": false,    // retain method/event closures by not serializing functions (breaks replication, persistence)
+            "load-timeout": 10,                   // resource load timeout in seconds
         },
 
         /// Changes for production environments.
 
         production: {
+            "load-timeout": 60,
         },
 
         /// Changes for development environments.
@@ -187,6 +189,7 @@ define( function() {
             "log-level": "info",
             "randomize-ids": true,
             "humanize-ids": true,
+            "load-timeout": 30,
         },
 
         /// Changes for testing environments.


### PR DESCRIPTION
@kadst43 @eric79 this will detect load errors, log a message to the console, and abort the fragment of the operation that failed.

The error needs to be handled better at the top. Maybe we shouldn't try to resume the operation yet, but let it still hang but with a message on the console now.