### PR TITLE
Disallows pick events when the mouse is not over canvas

### DIFF
--- a/public/bzflag/index.vwf.config.yaml
+++ b/public/bzflag/index.vwf.config.yaml
@@ -15,6 +15,8 @@
 model:
   vwf/model/threejs:
 view:
-  vwf/view/threejs: { application-root: "#vwf-root", experimental-disable-inputs: true }
+  vwf/view/threejs: 
+  	application-root: "#vwf-root"
+  	enable-inputs: false
 configuration:
   preserve-script-closures: true

--- a/support/client/lib/vwf/view/glge.js
+++ b/support/client/lib/vwf/view/glge.js
@@ -27,18 +27,18 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
             checkCompatibility.call(this);
 
             this.pickInterval = 10;
-            this.disableInputs = false;
+            this.enableInputs = true;
 
             // Store parameter options for persistence functionality
             this.parameters = options;
 
             if(typeof options == "object") {
                 this.rootSelector = options["application-root"];
-                if("experimental-pick-interval" in options) {
+                if("pick-interval" in options) {
                     this.pickInterval = options["experimental-pick-interval"];
                 }
-                if("experimental-disable-inputs" in options) {
-                    this.disableInputs = options["experimental-disable-inputs"];
+                if("enable-inputs" in options) {
+                    this.enableInputs = options["enable-inputs"];
                 }
             }
             else {
@@ -82,7 +82,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
                 ).children(":last");
 
                 var canvas = this.canvasQuery.get(0);
-                if(!this.disableInputs) {
+                if ( this.enableInputs ) {
                     window.onkeydown = function (event) {
                         var key = undefined;
                         var validKey = false;
@@ -243,7 +243,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
             time = time || 0;
             window.requestAnimationFrame( renderScene );
             sceneNode.frameCount++;
-            if((time - lastPickTime) > self.pickInterval && !self.disableInputs) {
+            if((time - lastPickTime) > self.pickInterval && self.enableInputs) {
                 var newPick = mousePick.call( this, mouse, sceneNode );
                 self.lastPick = newPick;
                 if((mouse.getMousePosition().x != oldMouseX || mouse.getMousePosition().y != oldMouseY)) {
@@ -278,7 +278,7 @@ define( [ "module", "vwf/view", "vwf/utility" ], function( module, view, utility
             this.state.cameraInUse.setAspect( ( canvas.width / canvas.height)  );
 
             // set up all of the mouse event handlers
-            if(!self.disableInputs) {
+            if( self.enableInputs ) {
                 initMouseEvents.call( this, canvas );
             }
 

--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -1788,7 +1788,6 @@ define( [ "module",
         // a document lost focus and force a mouse up as well. Rare occasion, but it's possible to lose focus 
         // while the mouse is down
         document.onmouseup = function( e ) {
-
             // Set appropriate button / key states
             var ctrlDown = e.ctrlKey;
             var atlDown = e.altKey;
@@ -1882,7 +1881,6 @@ define( [ "module",
         }
 
         canvas.onmouseover = function( e ) {
-            //console.info( "mouseOver +++++++++++++++++++++++" );
             if ( !self.mouseOverCanvas ) {
                 self.mouseJustEnteredCanvas = true;
                 self.mouseOverCanvas = true;
@@ -1896,7 +1894,7 @@ define( [ "module",
             e.preventDefault();
         }
 
-        canvas.onmousemove = function( e ) {
+        document.onmousemove = function( e ) {
 
             // HACK: This is to deal with an issue with webkitMovementX in Chrome:
             if ( nextMouseMoveIsErroneous ) {
@@ -1951,7 +1949,6 @@ define( [ "module",
         }
 
         canvas.onmouseout = function( e ) {
-            //console.info( "mouseOut  --------------------------" );
             if ( pointerOverID ) {
                 sceneView.kernel.dispatchEvent( pointerOverID, "pointerOut" );
                 pointerOverID = undefined;

--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -97,7 +97,7 @@ define( [ "module",
             this.state.appInitialized = false;
 
             this.pickInterval = 10;
-            this.disableInputs = false;
+            this.enableInputs = true;
             this.applicationWantsPointerEvents = false;
 
             // Store parameter options for persistence functionality
@@ -107,11 +107,11 @@ define( [ "module",
  
                 this.rootSelector = options[ "application-root" ];
 
-                if ( "experimental-pick-interval" in options ) {
-                    this.pickInterval = options[ "experimental-pick-interval" ];
+                if ( "pick-interval" in options ) {
+                    this.pickInterval = options[ "pick-interval" ];
                 }
-                if ( "experimental-disable-inputs" in options ) {
-                    this.disableInputs = options[ "experimental-disable-inputs" ];
+                if ( "enable-inputs" in options ) {
+                    this.enableInputs = options[ "enable-inputs" ];
                 }
                 enableStereo = ( options.stereo !== undefined ) ? options.stereo : false;
 
@@ -1139,7 +1139,7 @@ define( [ "module",
                     }
                 }
 
-                if ( navmode != "none" && !self.disableInputs ) {
+                if ( navmode != "none" && self.enableInputs ) {
 
                     // Move the user's camera according to their input
                     inputMoveNavObject( timepassed );
@@ -1153,53 +1153,58 @@ define( [ "module",
                 }
 
             }
-            
-            // Only do a pick every "pickInterval" ms. Defaults to 10 ms.
-            // Note: this is a costly operation and should be optimized if possible
-            if ( ( now - lastPickTime ) > self.pickInterval && !self.disableInputs )
-            {
-                sceneNode.frameCount = 0;
-            
-                var newPick, newPickId;
 
-                if ( self.applicationWantsPointerEvents ) {
-                    newPick = ThreeJSPick.call( self, mycanvas, sceneNode, false );
-                    newPickId = newPick ? getPickObjectID.call( view, newPick.object ) : view.state.sceneRootID;
-                } else {
-                    newPick = undefined;
-                    newPickId = undefined;
-                }
+            if ( self.mouseOverCanvas ) {
 
-                if ( self.lastPickId != newPickId && self.lastEventData )
+                // Only do a pick every "pickInterval" ms. Defaults to 10 ms.
+                // Note: this is a costly operation and should be optimized if possible
+                if ( ( self.mouseJustEnteredCanvas || ( ( now - lastPickTime ) > self.pickInterval ) ) && self.enableInputs )
                 {
-                    if ( self.lastPickId ) {
-                        view.kernel.dispatchEvent( self.lastPickId, "pointerOut", 
-                                                   self.lastEventData.eventData, 
-                                                   self.lastEventData.eventNodeData );
-                    }
-                    if ( newPickId ) {
-                        view.kernel.dispatchEvent( newPickId, "pointerOver",
-                                                   self.lastEventData.eventData, 
-                                                   self.lastEventData.eventNodeData );
-                    }
-                }
-
-                if ( view.lastEventData && 
-                     ( view.lastEventData.eventData[0].screenPosition[0] != oldMouseX || 
-                       view.lastEventData.eventData[0].screenPosition[1] != oldMouseY ) ) {
-                    oldMouseX = view.lastEventData.eventData[0].screenPosition[0];
-                    oldMouseY = view.lastEventData.eventData[0].screenPosition[1];
-                    hovering = false;
-                }
-                else if(self.lastEventData && self.mouseOverCanvas && !hovering && newPick) {
-                    view.kernel.dispatchEvent( newPickId, "pointerHover", self.lastEventData.eventData, self.lastEventData.eventNodeData );
-                    hovering = true;
-                }
+                    sceneNode.frameCount = 0;
                 
-                self.lastPickId = newPickId;
-                self.lastPick = newPick;
-                lastPickTime = now;
+                    var newPick, newPickId;
+
+                    if ( self.applicationWantsPointerEvents ) {
+                        newPick = ThreeJSPick.call( self, mycanvas, sceneNode, false );
+                        newPickId = newPick ? getPickObjectID.call( view, newPick.object ) : view.state.sceneRootID;
+                    } else {
+                        newPick = undefined;
+                        newPickId = undefined;
+                    }
+
+                    if ( self.lastPickId != newPickId && self.lastEventData )
+                    {
+                        if ( self.lastPickId ) {
+                            view.kernel.dispatchEvent( self.lastPickId, "pointerOut", 
+                                                       self.lastEventData.eventData, 
+                                                       self.lastEventData.eventNodeData );
+                        }
+                        if ( newPickId ) {
+                            view.kernel.dispatchEvent( newPickId, "pointerOver",
+                                                       self.lastEventData.eventData, 
+                                                       self.lastEventData.eventNodeData );
+                        }
+                    }
+
+                    if ( view.lastEventData && 
+                         ( view.lastEventData.eventData[0].screenPosition[0] != oldMouseX || 
+                           view.lastEventData.eventData[0].screenPosition[1] != oldMouseY ) ) {
+                        oldMouseX = view.lastEventData.eventData[0].screenPosition[0];
+                        oldMouseY = view.lastEventData.eventData[0].screenPosition[1];
+                        hovering = false;
+                    }
+                    else if(self.lastEventData && self.mouseOverCanvas && !hovering && newPick) {
+                        view.kernel.dispatchEvent( newPickId, "pointerHover", self.lastEventData.eventData, self.lastEventData.eventNodeData );
+                        hovering = true;
+                    }
+                    
+                    self.lastPickId = newPickId;
+                    self.lastPick = newPick;
+                    lastPickTime = now;
+                }
+                self.mouseJustEnteredCanvas = false;                
             }
+
 
             if ( enableStereo && sceneNode && sceneNode.stereo ) {
                 if ( mobileDevice && sceneNode.stereo.controls ) {
@@ -1340,7 +1345,7 @@ define( [ "module",
             window._dRenderer = renderer;
             window._dSceneNode = sceneNode;
             
-            if(!this.disableInputs) {
+            if ( this.enableInputs ) {
                 initInputEvents.call(this,mycanvas);
             }
             renderScene( ( +new Date ) );
@@ -1778,7 +1783,10 @@ define( [ "module",
 
         // Listen for onmouseup from the document (instead of the canvas like all the other mouse events)
         // because it will catch mouseup events that occur outside the window, whereas canvas.onmouseup does
-        // not.
+        // not.  
+        // We definitely want to catch this event regardless of where is occurs.  We might need to add 
+        // a document lost focus and force a mouse up as well. Rare occasion, but it's possible to lose focus 
+        // while the mouse is down
         document.onmouseup = function( e ) {
 
             // Set appropriate button / key states
@@ -1874,7 +1882,12 @@ define( [ "module",
         }
 
         canvas.onmouseover = function( e ) {
-            self.mouseOverCanvas = true;
+            console.info( "mouseOver +++++++++++++++++++++++" );
+            if ( !self.mouseOverCanvas ) {
+                self.mouseJustEnteredCanvas = true;
+                self.mouseOverCanvas = true;
+            }
+
             var eData = getEventData( e, false );
             if ( eData ) {
                 pointerOverID = pointerPickID ? pointerPickID : sceneID;
@@ -1938,6 +1951,7 @@ define( [ "module",
         }
 
         canvas.onmouseout = function( e ) {
+            console.info( "mouseOut  --------------------------" );
             if ( pointerOverID ) {
                 sceneView.kernel.dispatchEvent( pointerOverID, "pointerOut" );
                 pointerOverID = undefined;
@@ -1951,77 +1965,77 @@ define( [ "module",
         
         window.onkeydown = function (event) {
                     
-                    var key = undefined;
-                    var validKey = false;
-                    var keyAlreadyDown = false;
-                    switch ( event.keyCode ) {
-                        case 17:
-                        case 16:
-                        case 18:
-                        case 19:
-                        case 20:
-                            break;
-                        default:
-                            key = getKeyValue.call( sceneView, event.keyCode);
-                            keyAlreadyDown = !!sceneView.keyStates.keysDown[key.key];
-                            sceneView.keyStates.keysDown[key.key] = key;
-                            validKey = true;
+            var key = undefined;
+            var validKey = false;
+            var keyAlreadyDown = false;
+            switch ( event.keyCode ) {
+                case 17:
+                case 16:
+                case 18:
+                case 19:
+                case 20:
+                    break;
+                default:
+                    key = getKeyValue.call( sceneView, event.keyCode);
+                    keyAlreadyDown = !!sceneView.keyStates.keysDown[key.key];
+                    sceneView.keyStates.keysDown[key.key] = key;
+                    validKey = true;
 
-                            // TODO: Navigation - see main "TODO: Navigation" comment for explanation
-                            handleKeyNavigation( event.keyCode, true );
-                            // END TODO
+                    // TODO: Navigation - see main "TODO: Navigation" comment for explanation
+                    handleKeyNavigation( event.keyCode, true );
+                    // END TODO
 
-                            break;
-                    }
-                    
-                    if (!sceneView.keyStates.mods) sceneView.keyStates.mods = {};
-                    sceneView.keyStates.mods.alt = event.altKey;
-                    sceneView.keyStates.mods.shift = event.shiftKey;
-                    sceneView.keyStates.mods.ctrl = event.ctrlKey;
-                    sceneView.keyStates.mods.meta = event.metaKey;
+                    break;
+            }
+            
+            if (!sceneView.keyStates.mods) sceneView.keyStates.mods = {};
+            sceneView.keyStates.mods.alt = event.altKey;
+            sceneView.keyStates.mods.shift = event.shiftKey;
+            sceneView.keyStates.mods.ctrl = event.ctrlKey;
+            sceneView.keyStates.mods.meta = event.metaKey;
 
-                    var sceneNode = sceneView.state.scenes[sceneView.state.sceneRootID];
-                    if (validKey && sceneNode && !keyAlreadyDown /*&& Object.keys( sceneView.keyStates.keysDown ).length > 0*/) {
-                        //var params = JSON.stringify( sceneView.keyStates );
-                        sceneView.kernel.dispatchEvent(sceneNode.ID, "keyDown", [sceneView.keyStates]);
-                    }
-                };
+            var sceneNode = sceneView.state.scenes[sceneView.state.sceneRootID];
+            if (validKey && sceneNode && !keyAlreadyDown /*&& Object.keys( sceneView.keyStates.keysDown ).length > 0*/) {
+                //var params = JSON.stringify( sceneView.keyStates );
+                sceneView.kernel.dispatchEvent(sceneNode.ID, "keyDown", [sceneView.keyStates]);
+            }
+        };
 
          window.onkeyup = function (event) {
-                    var key = undefined;
-                    var validKey = false;
-                    switch (event.keyCode) {
-                        case 16:
-                        case 17:
-                        case 18:
-                        case 19:
-                        case 20:
-                            break;
-                        default:
-                            key = getKeyValue.call( sceneView, event.keyCode);
-                            delete sceneView.keyStates.keysDown[key.key];
-                            sceneView.keyStates.keysUp[key.key] = key;
-                            validKey = true;
+            var key = undefined;
+            var validKey = false;
+            switch (event.keyCode) {
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                    break;
+                default:
+                    key = getKeyValue.call( sceneView, event.keyCode);
+                    delete sceneView.keyStates.keysDown[key.key];
+                    sceneView.keyStates.keysUp[key.key] = key;
+                    validKey = true;
 
-                            // TODO: Navigation - see main "TODO: Navigation" comment for explanation
-                            handleKeyNavigation( event.keyCode, false );
-                            // END TODO
+                    // TODO: Navigation - see main "TODO: Navigation" comment for explanation
+                    handleKeyNavigation( event.keyCode, false );
+                    // END TODO
 
-                            break;
-                    }
-                    
-                    sceneView.keyStates.mods.alt = event.altKey;
-                    sceneView.keyStates.mods.shift = event.shiftKey;
-                    sceneView.keyStates.mods.ctrl = event.ctrlKey;
-                    sceneView.keyStates.mods.meta = event.metaKey;
+                    break;
+            }
+            
+            sceneView.keyStates.mods.alt = event.altKey;
+            sceneView.keyStates.mods.shift = event.shiftKey;
+            sceneView.keyStates.mods.ctrl = event.ctrlKey;
+            sceneView.keyStates.mods.meta = event.metaKey;
 
-                    var sceneNode = sceneView.state.scenes[sceneView.state.sceneRootID];
-                    if (validKey && sceneNode) {
-                        //var params = JSON.stringify( sceneView.keyStates );
-                        sceneView.kernel.dispatchEvent(sceneNode.ID, "keyUp", [sceneView.keyStates]);
-                        delete sceneView.keyStates.keysUp[key.key];
-                    }
-                };
+            var sceneNode = sceneView.state.scenes[sceneView.state.sceneRootID];
+            if (validKey && sceneNode) {
+                //var params = JSON.stringify( sceneView.keyStates );
+                sceneView.kernel.dispatchEvent(sceneNode.ID, "keyUp", [sceneView.keyStates]);
+                delete sceneView.keyStates.keysUp[key.key];
+            }
+        };
 
         window.oncontextmenu = function() {
             if ( navmode == "none" )
@@ -2489,7 +2503,7 @@ define( [ "module",
         for ( var i = 0; i < intersects.length && target === undefined; i++ ) {
             if ( debug ) {
                 for ( var j = 0; j < intersects.length; j++ ) { 
-                    console.info( j + ". " + intersects[ j ].object.name ) 
+                    console.info( j + ". " + getPickObjectID( intersects[ j ].object ) ); 
                 }
             }   
             if ( intersects[ i ].object.visible ) {

--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -1882,7 +1882,7 @@ define( [ "module",
         }
 
         canvas.onmouseover = function( e ) {
-            console.info( "mouseOver +++++++++++++++++++++++" );
+            //console.info( "mouseOver +++++++++++++++++++++++" );
             if ( !self.mouseOverCanvas ) {
                 self.mouseJustEnteredCanvas = true;
                 self.mouseOverCanvas = true;
@@ -1951,7 +1951,7 @@ define( [ "module",
         }
 
         canvas.onmouseout = function( e ) {
-            console.info( "mouseOut  --------------------------" );
+            //console.info( "mouseOut  --------------------------" );
             if ( pointerOverID ) {
                 sceneView.kernel.dispatchEvent( pointerOverID, "pointerOut" );
                 pointerOverID = undefined;


### PR DESCRIPTION
There will be more to changes to come on the entire mouse picking, but this is a good first round.

Also removes the double negative with inputs
ands removes the ‘experimental’ notation