### PR TITLE
don't create new watchers at every reload of a file

### DIFF
--- a/lib/nodejs/file-cache.js
+++ b/lib/nodejs/file-cache.js
@@ -69,10 +69,12 @@ function _FileCache( ) {
                 global.log( 'loading into cache: ' + path, 2 );
                 if ( self.enabled == true ) {
                     self.files.push( newentry );
-                    fs.watchFile( path, { }, function ( event, filename ) {
-                        global.log( newentry.path + ' has changed on disk', 2 );
-                        self.files.splice( self.files.indexOf( newentry ), 1 );
+                    var watcher = fs.watchFile( path, { }, function ( event, filename ) {
+                        global.log( this.entry.path + ' has changed on disk', 2 );
+                        self.files.splice( self.files.indexOf( this.entry ), 1 );
+                        fs.unwatchFile(path); //make sure not to create new watchers at every reload
                     } );
+                    watcher.entry = newentry;
                 }
                 callback( newentry );
                 return;


### PR DESCRIPTION
Each time a file is changed on disk, it is removed from the file-cache object. However, the watcher is not canceled. Next time the file is requested, a new watcher will be created. If the file is again modified, then served, you end up with three. These file system watchers need to be canceled when the file changes, and a new one created only when the file is reloaded as it is served.