### PR TITLE
Remove warning that fires unnecessarily during getState when kernel re-entry is blocked

### DIFF
--- a/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
+++ b/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
@@ -19,9 +19,6 @@ properties:
     get: |
       if ( !this.scene ) {
         this.scene = this.find( this.scenePath || "/" )[ 0 ];
-        if ( !this.scene ) {
-          this.logger.errorx( "scene.get", "Could not find scene node: '", this.scenePath, "'" );
-        }
       }
       return this.scene;
       //@ sourceURL=sceneGetter.scene.get


### PR DESCRIPTION
@allisoncorey would you mind reviewing?