### PR TITLE
Update pick direction

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -2438,7 +2438,7 @@ define( [ "module",
         var x = ( mousepos.x ) * 2 - 1;
         var y = -( mousepos.y ) * 2 + 1;
 
-        pickDirection.set( x, y, threeCam.near );
+        pickDirection.set( x, y, 0.5 );
 
         var camPos = new THREE.Vector3(
             threeCam.matrixWorld.elements[ 12 ],  
@@ -2481,7 +2481,7 @@ define( [ "module",
         var x = ( mousepos.x ) * 2 - 1;
         var y = -( mousepos.y ) * 2 + 1;
 
-        pickDirection.set( x, y, threeCam.near );
+        pickDirection.set( x, y, 0.5 );
 
         var camPos = new THREE.Vector3(
             threeCam.matrixWorld.elements[ 12 ],  


### PR DESCRIPTION
Rather than relying on the camera near property value to set the pick direction (which can be greater than 1), return to using 0.5.

This change corrects both the sandtable draw/pin capability as well as the default navigation. 

@scottnc27603 