### PR TITLE
Modern ids

### DIFF
--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -174,7 +174,7 @@ function OnConnection( socket ) {
     socket.pendingList = [ ];
 
     //Create a child in the application's 'clients.vwf' global to represent this client.
-    var clientMessage = { action: "createChild", parameters: [ "http-vwf-example-com-clients-vwf", socket.id, {} ], time: global.instances[ namespace ].getTime( ) };
+    var clientMessage = { action: "createChild", parameters: [ "http://vwf.example.com/clients.vwf", socket.id, {} ], time: global.instances[ namespace ].getTime( ) };
 
     // The time for the setState message should be the time the new client joins, so save that time
     var setStateTime = global.instances[ namespace ].getTime( );
@@ -271,7 +271,7 @@ function OnConnection( socket ) {
         delete global.instances[ namespace ].clients[ socket.id ];
         
         // Notify others of the disconnecting client.  Delete the child representing this client in the application's `clients.vwf` global.
-        var clientMessage = { action: "deleteChild", parameters: [ "http-vwf-example-com-clients-vwf", socket.id ], time: global.instances[ namespace ].getTime( ) };
+        var clientMessage = { action: "deleteChild", parameters: [ "http://vwf.example.com/clients.vwf", socket.id ], time: global.instances[ namespace ].getTime( ) };
         for ( var i in global.instances[ namespace ].clients ) {
             var client = global.instances[ namespace ].clients[ i ];
             if( client.id != socket.id ) {

--- a/lib/vwf/application/reflector.rb
+++ b/lib/vwf/application/reflector.rb
@@ -162,7 +162,7 @@ class VWF::Application::Reflector < Rack::SocketIO::Application
 
     broadcast "time" => session[:transport].time,
       "action" => "createChild",
-      "parameters" => [ "http-vwf-example-com-clients-vwf", id, {} ]
+      "parameters" => [ "http://vwf.example.com/clients.vwf", id, {} ]
 
   end
 
@@ -268,7 +268,7 @@ class VWF::Application::Reflector < Rack::SocketIO::Application
 
     broadcast "time" => session[:transport].time,
       "action" => "deleteChild",
-      "parameters" => [ "http-vwf-example-com-clients-vwf", id ]
+      "parameters" => [ "http://vwf.example.com/clients.vwf", id ]
 
     # Just log the disconnection if no clients are waiting for replication.
 

--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -2245,33 +2245,21 @@
             // of the descriptor. An existing ID is used when synchronizing to state drawn from
             // another client or to a previously-saved state.
 
-var useLegacyID = nodeID === 0 && childURI &&
-    ( childURI == "index.vwf" || childURI == "appscene.vwf" || childURI.indexOf( "http://vwf.example.com/" ) == 0 ) &&
-    childURI != "http://vwf.example.com/node.vwf";
-    
-useLegacyID = useLegacyID ||
-    childName === "camera" && nodeID === this.application(); // TODO: fix static ID references and remove; model/glge still expects a static ID for the camera
-
             if ( childComponent.id ) {  // incoming replication: pre-calculated id
                 childID = childComponent.id;
                 childIndex = this.children( nodeID ).length;
             } else if ( nodeID === 0 ) {  // global: component's URI or hash of its descriptor
                 childID = childURI ||
                     Crypto.MD5( JSON.stringify( childComponent ) ).toString();  // TODO: MD5 may be too slow here
-if ( useLegacyID ) {  // TODO: fix static ID references and remove
-    childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );  // TODO: fix static ID references and remove
-}
                 childIndex = childURI;
             } else {  // descendant: parent id + next from parent's sequence
-if ( useLegacyID ) {  // TODO: fix static ID references and remove
-    childID = ( childComponent.extends || this.kutility.protoNodeURI ) + "." + childName;  // TODO: fix static ID references and remove
-    childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );  // TODO: fix static ID references and remove
-    childIndex = this.children( nodeID ).length;
-} else {    
                 childID = nodeID + ":" + this.sequence( nodeID ) +
                     ( this.configuration["randomize-ids"] ? "-" + ( "0" + Math.floor( this.random( nodeID ) * 100 ) ).slice( -2 ) : "" ) +
                     ( this.configuration["humanize-ids"] ? "-" + childName.replace( /[^0-9A-Za-z_-]+/g, "-" ) : "" );
                 childIndex = this.children( nodeID ).length;
+if ( childName === "camera" && nodeID === this.application() ) {  // TODO: fix static ID references and remove
+    childID = ( childComponent.extends || this.kutility.protoNodeURI ) + "." + childName;
+    childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );
 }
             }
 

--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -2257,10 +2257,6 @@
                     ( this.configuration["randomize-ids"] ? "-" + ( "0" + Math.floor( this.random( nodeID ) * 100 ) ).slice( -2 ) : "" ) +
                     ( this.configuration["humanize-ids"] ? "-" + childName.replace( /[^0-9A-Za-z_-]+/g, "-" ) : "" );
                 childIndex = this.children( nodeID ).length;
-if ( childName === "camera" && nodeID === this.application() ) {  // TODO: fix static ID references and remove
-    childID = ( childComponent.extends || this.kutility.protoNodeURI ) + "." + childName;
-    childID = childID.replace( /[^0-9A-Za-z_]+/g, "-" );
-}
             }
 
             // Register the node.

--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -1416,7 +1416,7 @@
                 // Global node and descendant deltas.
 
                 nodes: [  // TODO: all global objects
-                    this.getNode( "http-vwf-example-com-clients-vwf", full ),
+                    this.getNode( "http://vwf.example.com/clients.vwf", full ),
                     this.getNode( this.application(), full ),
                 ],
 

--- a/support/client/lib/vwf/model/blockly.js
+++ b/support/client/lib/vwf/model/blockly.js
@@ -420,7 +420,7 @@ define( [ "module", "vwf/model", "vwf/utility",
         var found = false;
         if ( implementsIDs ) {
             for ( var i = 0; i < implementsIDs.length && !found; i++ ) {
-                found = ( implementsIDs[i] == "http-vwf-example-com-blockly-controller-vwf" ); 
+                found = ( implementsIDs[i] == "http://vwf.example.com/blockly/controller.vwf" );
             }
         }
        return found;

--- a/support/client/lib/vwf/model/buzz.js
+++ b/support/client/lib/vwf/model/buzz.js
@@ -52,7 +52,7 @@ define( [
                     var found = false;
                     if ( prototypes ) {
                         for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                            found = ( prototypes[ i ].indexOf( "http-vwf-example-com-sound3-vwf" ) != -1 );    
+                            found = ( prototypes[ i ] === "http://vwf.example.com/sound3.vwf" );
                         }
                     }
                     return found;
@@ -61,7 +61,7 @@ define( [
                     var found = false;
                     if ( prototypes ) {
                         for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                            found = ( prototypes[ i ].indexOf( "http-vwf-example-com-sound-vwf" ) != -1 );    
+                            found = ( prototypes[ i ] === "http://vwf.example.com/sound.vwf" );
                         }
                     }
                     return found;

--- a/support/client/lib/vwf/model/cesium.js
+++ b/support/client/lib/vwf/model/cesium.js
@@ -2054,7 +2054,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium.vwf" );
             }
         }
 
@@ -2066,7 +2066,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-globe-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/globe.vwf" );
             }
         }
 
@@ -2078,7 +2078,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-sun-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/sun.vwf" );
             }
         }
 
@@ -2090,7 +2090,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-atmosphere-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/atmosphere.vwf" );
             }
         }
 
@@ -2102,7 +2102,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-skybox-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/skybox.vwf" );
             }
         }
 
@@ -2114,7 +2114,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-billboard-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/billboard.vwf" );
             }
         }
 
@@ -2126,7 +2126,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-dynamicObject-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/dynamicObject.vwf" );
             }
         }
 
@@ -2138,7 +2138,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-label-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/label.vwf" );
             }
         }
 
@@ -2150,7 +2150,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-polylineCollection-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/polylineCollection.vwf" );
             }
         }
 
@@ -2162,7 +2162,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-polyline-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/polyline.vwf" );
             }
         }
 
@@ -2174,7 +2174,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-model-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/model.vwf" );
             }
         }
 
@@ -2186,7 +2186,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-geometry-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/geometry.vwf" );
             }
         }
 
@@ -2198,7 +2198,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-material-vwf" );   
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/material.vwf" );
             }
         }
 
@@ -2210,7 +2210,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-camera-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/camera.vwf" );
             }
         }
 
@@ -2222,7 +2222,7 @@ define( [ "module",
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-node3-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/node3.vwf" );
             }
         }
 

--- a/support/client/lib/vwf/model/cesium.js
+++ b/support/client/lib/vwf/model/cesium.js
@@ -530,10 +530,10 @@ define( [ "module",
             } else if ( isCamera.call( this, protos ) ) {
                 this.state.nodes[ childID ] = node = createSceneNode( childID );
 
-                if ( childID === "http-vwf-example-com-cesium-camera-vwf-camera" ) {
+                if ( nodeID === this.kernel.application() && childName === 'camera' ) {
                     node.cesiumObj = node.sceneNode.scene.camera;
                 } else {
-                    var camera = new Cesium.Camera(canvas);
+                    var camera = new Cesium.Camera( canvas );
                     camera.position = toCartesian3();
                     camera.direction = Cartesian3.UNIT_Z.negate();
                     camera.up = Cartesian3.UNIT_Y;

--- a/support/client/lib/vwf/model/glge.js
+++ b/support/client/lib/vwf/model/glge.js
@@ -330,12 +330,12 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
             } else {
 
                 switch ( childExtendsID ) {
-                    case "appscene-vwf":
-                    case "index-vwf":
+                    case "appscene.vwf":
+                    case "index.vwf":
                     case "http://vwf.example.com/node.vwf":
-                    case "http-vwf-example-com-node2-vwf":
-                    case "http-vwf-example-com-scene-vwf":
-                    case "http-vwf-example-com-navscene-vwf":
+                    case "http://vwf.example.com/node2.vwf":
+                    case "http://vwf.example.com/scene.vwf":
+                    case "http://vwf.example.com/navscene.vwf":
                     case undefined:
                         break;
 
@@ -1878,27 +1878,27 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                 glgeObjName = name( assetObj );
                 if ( glgeObjName == objName ) {
                     switch ( type ) {
-                        case "http-vwf-example-com-mesh-vwf":
+                        case "http://vwf.example.com/mesh.vwf":
                             if ( assetObj.constructor == GLGE.Object )
                                 obj = assetObj;
                             break;
-                        case "http-vwf-example-com-node3-vwf":
+                        case "http://vwf.example.com/node3.vwf":
                             if ( ( assetObj.constructor == GLGE.Group ) || ( assetObj.constructor == GLGE.Object ) )
                                 obj = assetObj;
                             break;
-                        case "http-vwf-example-com-light-vwf":
+                        case "http://vwf.example.com/light.vwf":
                             if ( assetObj.constructor == GLGE.Light )
                                 obj = assetObj;
                             break;
-                        case "http-vwf-example-com-camera-vwf":
+                        case "http://vwf.example.com/camera.vwf":
                             if ( assetObj.constructor == GLGE.Camera )
                                 obj = assetObj;
                             break;
-                        case "http-vwf-example-com-scene-vwf":
+                        case "http://vwf.example.com/scene.vwf":
                             if ( assetObj.constructor == GLGE.Scene )
                                 obj = assetObj;
                             break;
-                        case "http-vwf-example-com-particleSystem-vwf":
+                        case "http://vwf.example.com/particleSystem.vwf":
                             if ( assetObj.constructor == GLGE.ParticleSystem )
                                 obj = assetObj;
                             break;
@@ -2307,7 +2307,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-navscene-vwf" || prototypes[i] == "http-vwf-example-com-scene-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/navscene.vwf" || prototypes[i] == "http://vwf.example.com/scene.vwf" );
             }
         }
 
@@ -2318,7 +2318,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-node3-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/node3.vwf" );
             }
         }
 
@@ -2329,7 +2329,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-camera-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/camera.vwf" );
             }
         }
 
@@ -2340,7 +2340,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-light-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/light.vwf" );
             }
         }
 
@@ -2351,7 +2351,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-particlesystem-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/particlesystem.vwf" );
             }
         }
 
@@ -2362,7 +2362,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var foundGlge = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGlge; i++ ) {
-                foundGlge = ( prototypes[i] == "http-vwf-example-com-material-vwf" );    
+                foundGlge = ( prototypes[i] == "http://vwf.example.com/material.vwf" );
             }
         }
 

--- a/support/client/lib/vwf/model/glge.js
+++ b/support/client/lib/vwf/model/glge.js
@@ -331,7 +331,6 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
 
                 switch ( childExtendsID ) {
                     case "appscene.vwf":
-                    case "index.vwf":
                     case "http://vwf.example.com/node.vwf":
                     case "http://vwf.example.com/node2.vwf":
                     case "http://vwf.example.com/scene.vwf":

--- a/support/client/lib/vwf/model/glge.js
+++ b/support/client/lib/vwf/model/glge.js
@@ -112,9 +112,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                     glgeKeys: new GLGE.KeyInput(),
                     type: childExtendsID,
                     camera: {
-                        ID: undefined,
-                        defaultCamID: "http-vwf-example-com-camera-vwf-camera",
-                        glgeCameras: {},
+                        ID: undefined
                     },
                     xmlColladaObjects: [],
                     srcColladaObjects: [],
@@ -124,7 +122,6 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                 };
 				
                 if ( sceneNode.glgeScene.camera ) {
-                    sceneNode.camera.glgeCameras[ sceneNode.camera.defaultCamID ] = sceneNode.glgeScene.camera;
                     sceneNode.glgeScene.camera.name = "camera";
                     this.state.cameraInUse = sceneNode.glgeScene.camera;
                     initCamera.call( this, sceneNode.glgeScene.camera );
@@ -162,24 +159,11 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                         sourceType: childType,
                     };
 
-                    if ( nodeID != 0 && !node.glgeObject ) {
+                    if ( nodeID === this.kernel.application() && childName === "camera" ) {
+
+                    } else if ( node.glgeObject === undefined ){
                         createCamera.call( this, nodeID, childID, childName );
                     }
-
-                    if ( sceneNode && sceneNode.camera ) {
-                        if ( childID == sceneNode.camera.defaultCamID ) {
-                            if ( !sceneNode.camera.glgeCameras[ childID ] ) {
-                                var cam = new GLGE.Camera();
-                                sceneNode.camera.glgeCameras[ childID ] = cam;
-                                initCamera.call( this, cam );
-                            }
-                            node.name = camName;
-                            node.glgeObject = sceneNode.camera.glgeCameras[ childID ];
-                      
-                        } else if ( node.glgeObject ) {
-                            sceneNode.camera.glgeCameras[ childID ] = node.glgeObject;
-                        }
-                    } 
                 }              
             } else if ( prototypes && isGlgeLightDefinition.call( this, prototypes ) ) {
                 if ( childName !== undefined ) {
@@ -327,28 +311,6 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                     };
                     findMaterial.call( this, nodeID, childName, node );
                 }
-            } else {
-
-                switch ( childExtendsID ) {
-                    case "appscene.vwf":
-                    case "http://vwf.example.com/node.vwf":
-                    case "http://vwf.example.com/node2.vwf":
-                    case "http://vwf.example.com/scene.vwf":
-                    case "http://vwf.example.com/navscene.vwf":
-                    case undefined:
-                        break;
-
-                    default:
-                        node = this.state.nodes[ childID ] = {
-                            name: childName,
-                            glgeObject: glgeChild,
-                            ID: childID,
-                            parentID: nodeID,
-                            type: childExtendsID,
-                            sourceType: childType,
-                        };
-                        break;
-                 }  // end of switch
             } // end of else
 
             // If we do not have a load a model for this node, then we are almost done, so we can update all
@@ -1965,30 +1927,17 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         if ( sceneNode && parent ) {
             var child = this.state.nodes[childID];
             if ( child ) {
-                var cam;
-                if ( sceneNode.camera && sceneNode.camera.glgeCameras ) {
-                    if ( !sceneNode.camera.glgeCameras[childID] ) {
-                        cam = new GLGE.Camera();
-                        initCamera.call( this, cam );
-                        sceneNode.camera.glgeCameras[childID] = cam;
-                    } else {
-                        cam = sceneNode.camera.glgeCameras[childID];
-                    }
-                    var glgeParent = parent.glgeObject;
-                    if ( glgeParent && ( glgeParent instanceof GLGE.Scene || glgeParent instanceof GLGE.Group )) {
-                        glgeParent.addObject( cam );
-                    }
-
-                    var glgeParent = parent.glgeObject;
-                    if ( glgeParent && ( glgeParent instanceof GLGE.Scene || glgeParent instanceof GLGE.Group )) {
-                        glgeParent.addObject( cam );
-                    }
-
-                    child.name = childName;
-                    child.glgeObject = cam;
-                    child.uid = child.glgeObject.uid;
-                    cam.name = childName;
+                var cam = new GLGE.Camera();;
+                initCamera.call( this, cam );
+                var glgeParent = parent.glgeObject;
+                if ( glgeParent && ( glgeParent instanceof GLGE.Scene || glgeParent instanceof GLGE.Group )) {
+                    glgeParent.addObject( cam );
                 }
+
+                child.name = childName;
+                child.glgeObject = cam;
+                child.uid = child.glgeObject.uid;
+                cam.name = childName;
             }
         }  
 

--- a/support/client/lib/vwf/model/glge.js
+++ b/support/client/lib/vwf/model/glge.js
@@ -149,7 +149,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
            
             } else if ( prototypes && isGlgeCameraDefinition.call( this, prototypes ) ) {
                 if ( childName !== undefined ) {
-                    var camName = childID.substring( childID.lastIndexOf( '-' ) + 1 );
+                    var camName = this.kernel.name( childID );
                     var sceneNode = this.state.scenes[ this.state.sceneRootID ];
                     node = this.state.nodes[childID] = {
                         name: childName,

--- a/support/client/lib/vwf/model/graphtool.js
+++ b/support/client/lib/vwf/model/graphtool.js
@@ -337,7 +337,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
 
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundGraph; i++ ) {
-                foundGraph = ( prototypes[i] == "http-vwf-example-com-graphtool-graph-vwf" );    
+                foundGraph = ( prototypes[i] == "http://vwf.example.com/graphtool/graph.vwf" );
             }
         }
 
@@ -350,10 +350,10 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
 
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundObject; i++ ) {
-                foundObject = ( prototypes[i] == "http-vwf-example-com-graphtool-graphline-vwf" ) ||
-                    ( prototypes[i] == "http-vwf-example-com-graphtool-graphlinefunction-vwf" ) ||
-                    ( prototypes[i] == "http-vwf-example-com-graphtool-graphplane-vwf" ) ||
-                    ( prototypes[i] == "http-vwf-example-com-graphtool-graphgroup-vwf" );
+                foundObject = ( prototypes[i] == "http://vwf.example.com/graphtool/graphline.vwf" ) ||
+                    ( prototypes[i] == "http://vwf.example.com/graphtool/graphlinefunction.vwf" ) ||
+                    ( prototypes[i] == "http://vwf.example.com/graphtool/graphplane.vwf" ) ||
+                    ( prototypes[i] == "http://vwf.example.com/graphtool/graphgroup.vwf" );
             }
         }
 
@@ -364,13 +364,13 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
 
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length; i++ ) {
-                if ( prototypes[i] == "http-vwf-example-com-graphtool-graphline-vwf" ) {
+                if ( prototypes[i] == "http://vwf.example.com/graphtool/graphline.vwf" ) {
                     return "line";
-                } else if ( prototypes[i] == "http-vwf-example-com-graphtool-graphlinefunction-vwf" ) {
+                } else if ( prototypes[i] == "http://vwf.example.com/graphtool/graphlinefunction.vwf" ) {
                     return "function";
-                } else if ( prototypes[i] == "http-vwf-example-com-graphtool-graphplane-vwf" ) {
+                } else if ( prototypes[i] == "http://vwf.example.com/graphtool/graphplane.vwf" ) {
                     return "plane";
-                } else if ( prototypes[i] == "http-vwf-example-com-graphtool-graphgroup-vwf" ) {
+                } else if ( prototypes[i] == "http://vwf.example.com/graphtool/graphgroup.vwf" ) {
                     return "group";
                 }
             }

--- a/support/client/lib/vwf/model/heightmap.js
+++ b/support/client/lib/vwf/model/heightmap.js
@@ -102,7 +102,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[ i ] === "http-vwf-example-com-heightmap-vwf" );    
+                found = ( prototypes[ i ] === "http://vwf.example.com/heightmap.vwf" );
             }
         }
         return found;

--- a/support/client/lib/vwf/model/jPlayer.js
+++ b/support/client/lib/vwf/model/jPlayer.js
@@ -12,8 +12,8 @@ define( [
 
     var modelDriver;
     var jPlayerInstanceCreated = false;
-    var audioManagerProtoId = "http-vwf-example-com-jplayer-audioManager-vwf";
-    var videoManagerProtoId = "http-vwf-example-com-jplayer-videoManager-vwf";
+    var audioManagerProtoId = "http://vwf.example.com/jplayer/audioManager.vwf";
+    var videoManagerProtoId = "http://vwf.example.com/jplayer/videoManager.vwf";
 
     return model.load( module, {
 

--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -2223,7 +2223,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-stage-vwf"  );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/stage.vwf"  );
             }
         }
         return found;
@@ -2232,7 +2232,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-layer-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/layer.vwf" );
             }
         }
         return found;
@@ -2241,7 +2241,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-canvas-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/canvas.vwf" );
             }
         }
         return found;
@@ -2250,7 +2250,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-shape-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/shape.vwf" );
             }
         }
         return found;
@@ -2259,7 +2259,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-container-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/container.vwf" );
             }
         }
         return found;
@@ -2268,7 +2268,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-kinetic-node-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/kinetic/node.vwf" );
             }
         }
         return found;

--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -42,13 +42,10 @@ define( [ "module",
                         "uniqueInView": false
                     };
                 },
-                isKineticClass: function( prototypes, classIDArray ) {
+                isKineticClass: function( prototypes, classID ) {
                     if ( prototypes ) {
-                        var id1 = classIDArray.join( '.' ).toLowerCase();
-                        var id2 = classIDArray.join( '-' ).toLowerCase();
                         for ( var i = 0; i < prototypes.length; i++ ) {
-                            if ( prototypes[ i ].toLowerCase().indexOf( id1 ) !== -1 || 
-                                 prototypes[ i ].toLowerCase().indexOf( id2 ) !== -1 ) {
+                            if ( prototypes[ i ] === classID ) {
                                 //console.info( "prototypes[ i ]: " + prototypes[ i ] );
                                 return true;
                             }
@@ -60,7 +57,7 @@ define( [ "module",
                     var found = false;
                     if ( prototypes ) {
                         for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                            found = ( prototypes[ i ].indexOf( "http-vwf-example-com-kinetic-" ) != -1 );    
+                            found = ( prototypes[ i ] === "http://vwf.example.com/kinetic/node.vwf" );
                         }
                     }
                     return found;
@@ -2106,21 +2103,21 @@ define( [ "module",
         var protos = node.prototypes;
         var kineticObj = undefined;
 
-        if ( self.state.isKineticClass( protos, [ "kinetic", "arc", "vwf" ] ) ) {
+        if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/arc.vwf" ) ) {
             kineticObj = new Kinetic.Arc( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "baselayer", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/baseLayer.vwf" ) ) {
             kineticObj = new Kinetic.BaseLayer( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "canvas", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/canvas.vwf" ) ) {
             kineticObj = new Kinetic.Canvas( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "circle", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/circle.vwf" ) ) {
             kineticObj = new Kinetic.Circle( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "ellipse", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/ellipse.vwf" ) ) {
             kineticObj = new Kinetic.Ellipse( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "fastlayer", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/fastLayer.vwf" ) ) {
             kineticObj = new Kinetic.FastLayer( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "group", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/group.vwf" ) ) {
             kineticObj = new Kinetic.Group( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "image", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/image.vwf" ) ) {
             var imageObj = new Image();
             node.scaleOnLoad = false;
             kineticObj = new Kinetic.Image( {
@@ -2129,19 +2126,19 @@ define( [ "module",
             if ( node.source !== undefined ) {
                 imageObj.src = node.source;    
             }
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "layer", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/layer.vwf" ) ) {
             kineticObj = new Kinetic.Layer( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "line", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/line.vwf" ) ) {
             kineticObj = new Kinetic.Line( config || { "points": [] } );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "path", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/path.vwf" ) ) {
             kineticObj = new Kinetic.Path( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "rect", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/rect.vwf" ) ) {
             kineticObj = new Kinetic.Rect( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "regularpolygon", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/regularPolygon.vwf" ) ) {
             kineticObj = new Kinetic.RegularPolygon( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "ring", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/ring.vwf" ) ) {
             kineticObj = new Kinetic.Ring( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "sprite", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/sprite.vwf" ) ) {
             var imageObj = new Image();
             node.scaleOnLoad = false;
             kineticObj = new Kinetic.Sprite( {
@@ -2150,7 +2147,7 @@ define( [ "module",
             if ( node.source !== undefined ) {
                 imageObj.src = node.source;    
             }
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "stage", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/stage.vwf" ) ) {
             var stageWidth = ( window && window.innerWidth ) ? window.innerWidth : 800;
             var stageHeight = ( window && window.innerHeight ) ? window.innerHeight : 600;
             var stageContainer = ( config && config.container ) || 'vwf-root';
@@ -2163,19 +2160,19 @@ define( [ "module",
             };
             kineticObj = new Kinetic.Stage( stageDef );
             self.state.stages[ node.ID ] = kineticObj;
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "star", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/star.vwf" ) ) {
             kineticObj = new Kinetic.Star( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "text", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/text.vwf" ) ) {
             kineticObj = new Kinetic.Text( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "textpath", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/textPath.vwf" ) ) {
             kineticObj = new Kinetic.TextPath( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "wedge", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/wedge.vwf" ) ) {
             kineticObj = new Kinetic.Wedge( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "shape", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/shape.vwf" ) ) {
             kineticObj = new Kinetic.Shape( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "container", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/container.vwf" ) ) {
             kineticObj = new Kinetic.Container( config || {} );
-        } else if ( self.state.isKineticClass( protos, [ "kinetic", "node", "vwf" ] ) ) {
+        } else if ( self.state.isKineticClass( protos, "http://vwf.example.com/kinetic/node.vwf" ) ) {
             kineticObj = new Kinetic.Node( config || {} );
         }
 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -440,7 +440,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "unit-vwf" || prototypes[i] == "unit.vwf" ); 
+                found = ( prototypes[i] == "unit.vwf" );
             }
         }
        return found;
@@ -450,7 +450,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "modifier-vwf" || prototypes[i] == "modifier.vwf" ); 
+                found = ( prototypes[i] == "modifier.vwf" );
             }
         }
        return found;

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -191,11 +191,11 @@ define( [ "module",
                 if ( childImplementsIDs && childImplementsIDs.length > 0 ) {
                     for ( var i = 0; i < childImplementsIDs.length; i++ ) {
                         switch ( childImplementsIDs[ i ] ) {
-                            case "http-vwf-example-com-threejs-fogExp2-vwf":
+                            case "http://vwf.example.com/threejs/fogExp2.vwf":
                                 sceneNode.threeScene.fog = new THREE.FogExp2( 0x000000 );
                                 break;
 
-                            case "http-vwf-example-com-threejs-fog-vwf":
+                            case "http://vwf.example.com/threejs/fog.vwf":
                                 sceneNode.threeScene.fog = new THREE.Fog( 0x000000 );
                                 break;
 
@@ -268,25 +268,25 @@ define( [ "module",
                                 child = node.threeObject.children[ j ];
                                 switch ( childExtendsID ) {
                     
-                                    case "http-vwf-example-com-directionallight-vwf":
+                                    case "http://vwf.example.com/directionallight.vwf":
                                         if ( child instanceof THREE.DirectionalLight ) {
                                             light = child;    
                                         }
                                         break;
 
-                                    case "http-vwf-example-com-spotlight-vwf":
+                                    case "http://vwf.example.com/spotlight.vwf":
                                         if ( child instanceof THREE.SpotLight ) {
                                             light = child;    
                                         }
                                         break;
 
-                                    case "http-vwf-example-com-hemispherelight-vwf":
+                                    case "http://vwf.example.com/hemispherelight.vwf":
                                         if ( child instanceof THREE.HemisphereLight ) {
                                             light = child;    
                                         }
                                         break;
 
-                                    case "http-vwf-example-com-pointlight-vwf":
+                                    case "http://vwf.example.com/pointlight.vwf":
                                     default:
                                         if ( child instanceof THREE.PointLight ) {
                                             light = child;    
@@ -2441,7 +2441,7 @@ define( [ "module",
         var foundScene = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundScene; i++ ) {
-                foundScene = ( prototypes[i] == "http-vwf-example-com-navscene-vwf" || prototypes[i] == "http-vwf-example-com-scene-vwf" );    
+                foundScene = ( prototypes[i] == "http://vwf.example.com/navscene.vwf" || prototypes[i] == "http://vwf.example.com/scene.vwf" );
             }
         }
 
@@ -2451,7 +2451,7 @@ define( [ "module",
         var foundMaterial = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundMaterial; i++ ) {
-                foundMaterial = ( prototypes[i] == "http-vwf-example-com-material-vwf" );    
+                foundMaterial = ( prototypes[i] == "http://vwf.example.com/material.vwf" );
             }
         }
 
@@ -2461,7 +2461,7 @@ define( [ "module",
         var foundMaterial = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundMaterial; i++ ) {
-                foundMaterial = ( prototypes[i] == "http-vwf-example-com-shaderMaterial-vwf" );    
+                foundMaterial = ( prototypes[i] == "http://vwf.example.com/shaderMaterial.vwf" );
             }
         }
 
@@ -2471,7 +2471,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-threejs-uniforms-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/threejs/uniforms.vwf" );
             }
         }
 
@@ -2481,7 +2481,7 @@ define( [ "module",
         var found = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !found; i++ ) {
-                found = ( prototypes[i] == "http-vwf-example-com-texture-vwf" );    
+                found = ( prototypes[i] == "http://vwf.example.com/texture.vwf" );
             }
         }
 
@@ -2491,7 +2491,7 @@ define( [ "module",
         var foundCamera = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundCamera; i++ ) {
-                foundCamera = ( prototypes[i] == "http-vwf-example-com-camera-vwf" );    
+                foundCamera = ( prototypes[i] == "http://vwf.example.com/camera.vwf" );
             }
         }
 
@@ -2501,7 +2501,7 @@ define( [ "module",
         var foundSystem = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundSystem; i++ ) {
-                foundSystem = ( prototypes[i] == "http-vwf-example-com-particlesystem-vwf" );    
+                foundSystem = ( prototypes[i] == "http://vwf.example.com/particlesystem.vwf" );
             }
         }
 
@@ -2513,7 +2513,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-node3-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/node3.vwf" );
             }
         }
 
@@ -2524,7 +2524,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-starfield-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/starfield.vwf" );
             }
         }
         return foundNode;
@@ -2533,7 +2533,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-cube-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/cube.vwf" );
             }
         }
         return foundNode;
@@ -2542,7 +2542,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-circle-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/circle.vwf" );
             }
         }
         return foundNode;
@@ -2551,7 +2551,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-plane-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/plane.vwf" );
             }
         }
         return foundNode;
@@ -2560,7 +2560,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-sphere-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/sphere.vwf" );
             }
         }
         return foundNode;
@@ -2569,7 +2569,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-cylinder-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/cylinder.vwf" );
             }
         }
         return foundNode;
@@ -2578,7 +2578,7 @@ define( [ "module",
         var foundNode = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundNode; i++ ) {
-                foundNode = ( prototypes[i] == "http-vwf-example-com-threejs-text-vwf" );    
+                foundNode = ( prototypes[i] == "http://vwf.example.com/threejs/text.vwf" );
             }
         }
         return foundNode;
@@ -3652,7 +3652,7 @@ define( [ "module",
         var foundLight = false;
         if ( prototypes ) {
             for ( var i = 0; i < prototypes.length && !foundLight; i++ ) {
-                foundLight = ( prototypes[i] == "http-vwf-example-com-light-vwf" );    
+                foundLight = ( prototypes[i] == "http://vwf.example.com/light.vwf" );
             }
         }
 
@@ -3665,19 +3665,19 @@ define( [ "module",
 
             switch( type ) {
                 
-                case "http-vwf-example-com-directionallight-vwf":
+                case "http://vwf.example.com/directionallight.vwf":
                     child.threeObject = new THREE.DirectionalLight( 'FFFFFF' );
                     break;
 
-                case "http-vwf-example-com-spotlight-vwf":
+                case "http://vwf.example.com/spotlight.vwf":
                     child.threeObject = new THREE.SpotLight( 'FFFFFF' );
                     break;
 
-                case "http-vwf-example-com-hemispherelight-vwf":
+                case "http://vwf.example.com/hemispherelight.vwf":
                     child.threeObject = new THREE.HemisphereLight('FFFFFF','FFFFFF',1);
                     break;
 
-                case "http-vwf-example-com-pointlight-vwf":
+                case "http://vwf.example.com/pointlight.vwf":
                 default:
                     child.threeObject = new THREE.PointLight( 'FFFFFF', 1, 1000 );
                     break;    

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -206,7 +206,7 @@ define( [ "module",
             
             if ( protos && isCameraDefinition.call( this, protos ) ) {
 
-                var camName = childID.substring( childID.lastIndexOf( '-' ) + 1 );
+                var camName = this.kernel.name( childID );
                 var sceneNode = this.state.scenes[ this.state.sceneRootID ];
                 node = this.state.nodes[childID] = {
                     name: childName,

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -348,7 +348,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
         var found = false;
         if ( implementsIDs ) {
             for ( var i = 0; i < implementsIDs.length && !found; i++ ) {
-                found = ( implementsIDs[i] == "http-vwf-example-com-blockly-controller-vwf" ); 
+                found = ( implementsIDs[i] == "http://vwf.example.com/blockly/controller.vwf" );
             }
         }
        return found;

--- a/support/client/lib/vwf/view/cesium.js
+++ b/support/client/lib/vwf/view/cesium.js
@@ -379,7 +379,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/model/cesium/Cesium", "jquer
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium.vwf" );
             }
         }
 
@@ -391,7 +391,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/model/cesium/Cesium", "jquer
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-sun-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/sun.vwf" );
             }
         }
 
@@ -403,7 +403,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/model/cesium/Cesium", "jquer
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-atmosphere-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/atmosphere.vwf" );
             }
         }
 
@@ -415,7 +415,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/model/cesium/Cesium", "jquer
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundCesium; i++ ) {
-                foundCesium = ( prototypes[i] == "http-vwf-example-com-cesium-skybox-vwf" );    
+                foundCesium = ( prototypes[i] == "http://vwf.example.com/cesium/skybox.vwf" );
             }
         }
 

--- a/support/client/lib/vwf/view/editor.js
+++ b/support/client/lib/vwf/view/editor.js
@@ -20,7 +20,15 @@
 /// @requires vwf/view
 /// @requires vwf/utility
 
-define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui", "jquery-encoder-0.1.0" ], function( module, version, view, utility, $ ) {
+define( [ 
+    "module", 
+    "version", 
+    "vwf/view", 
+    "vwf/utility", 
+    "jquery", 
+    "jquery-ui", 
+    "jquery-encoder-0.1.0" 
+    ], function( module, version, view, utility, $ ) {
 
     return view.load( module, {
 
@@ -57,6 +65,8 @@ define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui",
             this.currentModelURL = '';
             this.highlightedChild = '';
             this.intervalTimer = 0;
+
+            this.activeCameraID = undefined;
             
             $('body').append(
                 "<div id='editor' class='relClass'>\n" +
@@ -190,6 +200,10 @@ define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui",
                 });
                 $('#children > div:last').css('border-bottom-width', '3px');
             }
+
+            if ( nodeID === this.kernel.application() && childName === 'camera' ) {
+                this.activeCameraID = childID;    
+            }
         },
         
         createdProperty: function (nodeID, propertyName, propertyValue) {
@@ -235,6 +249,12 @@ define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui",
                 node.properties.push( property );
             }
             
+            if ( propertyName === "activeCamera" ) {
+                if ( this.nodes[ propertyValue ] !== undefined ) {
+                    this.activeCameraID = propertyValue;
+                }
+            }
+
             try {
                 propertyValue = utility.transform( propertyValue, utility.transforms.transit );
                 node.properties[ propertyName ].value = JSON.stringify( propertyValue );
@@ -316,12 +336,10 @@ define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui",
 
     function updateCameraProperties () {
 
-        var cameraNodeName = "http-vwf-example-com-camera-vwf-camera";
-        
-        if ( this.currentNodeID == cameraNodeName ) {
+        if ( this.currentNodeID == this.activeCameraID ) {
             if ( !this.intervalTimer ) {
                 var self = this;
-                this.intervalTimer = setInterval( function() {updateProperties.call( self, cameraNodeName )}, 200 );
+                this.intervalTimer = setInterval( function() { updateProperties.call( self, self.activeCameraID ) }, 200 );
             }
         }
         else {

--- a/support/client/lib/vwf/view/editor.js
+++ b/support/client/lib/vwf/view/editor.js
@@ -600,7 +600,7 @@ define( [ "module", "version", "vwf/view", "vwf/utility", "jquery", "jquery-ui",
         
         
         var clients$ = $(this.clientList);
-        var node = this.nodes[ "http-vwf-example-com-clients-vwf" ];
+        var node = this.nodes[ "http://vwf.example.com/clients.vwf" ];
 
         clients$.html("<div class='header'>Connected Clients</div>");
 

--- a/support/client/lib/vwf/view/google-earth.js
+++ b/support/client/lib/vwf/view/google-earth.js
@@ -66,7 +66,7 @@ define( [ "module", "vwf/view", "jquery" ], function( module, view, jQuery ) {
             var win;
     
             switch ( childExtendsID.toLowerCase() ) {
-                case "http-vwf-example-com-googleearth-vwf":
+                case "http://vwf.example.com/googleearth.vwf":
                     this.state.scenes[ childID ] = node;
                     var outerDiv = jQuery('body').append(
                         "<div id='map3d' style='border: 1px solid silver; width: " + this.width + "px; height: " + this.height + "px;'></div>"
@@ -75,7 +75,7 @@ define( [ "module", "vwf/view", "jquery" ], function( module, view, jQuery ) {
                    window.onresize = function( event ) { console.info( "WINDOW: onresize" ); }
                    break;
 
-                case "http-vwf-example-com-node3-vwf":
+                case "http://vwf.example.com/node3.vwf":
                     
                     this.state.nodes[ childID ] = node;
                     var view = this;

--- a/support/client/lib/vwf/view/webrtc.js
+++ b/support/client/lib/vwf/view/webrtc.js
@@ -418,7 +418,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
             clr = clr.toArray(); 
         }
 
-        this.kernel.callMethod( "index.vwf", "createVideo", [ {
+        this.kernel.callMethod( this.kernel.application(), "createVideo", [ {
             "ID": id,
             "url": url, 
             "name": name, 
@@ -439,7 +439,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
             client.videoDivID = undefined;
         }
 
-        this.kernel.callMethod( "index.vwf", "removeVideo", [ client.moniker ] );
+        this.kernel.callMethod( this.kernel.application(), "removeVideo", [ client.moniker ] );
 
     }
 

--- a/support/client/lib/vwf/view/webrtc.js
+++ b/support/client/lib/vwf/view/webrtc.js
@@ -191,8 +191,8 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
             }
             // debugger;
 
-            if ( nodeID.indexOf( "-clients-vwf" ) != -1 ) {
-                var moniker = nodeID.substr( nodeID.lastIndexOf('-')+1, 16 );
+            if ( this.kernel.find( nodeID, "parent::element(*,'http://vwf.example.com/clients.vwf')" ).length > 0 ) {
+                var moniker = this.kernel.name( nodeID );
                 var client = undefined;
 
                 if ( moniker == this.kernel.moniker() ) {

--- a/support/client/lib/vwf/view/webrtc.js
+++ b/support/client/lib/vwf/view/webrtc.js
@@ -418,7 +418,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
             clr = clr.toArray(); 
         }
 
-        this.kernel.callMethod( "index-vwf", "createVideo", [ { 
+        this.kernel.callMethod( "index.vwf", "createVideo", [ {
             "ID": id,
             "url": url, 
             "name": name, 
@@ -439,7 +439,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
             client.videoDivID = undefined;
         }
 
-        this.kernel.callMethod( "index-vwf", "removeVideo", [ client.moniker ] ); 
+        this.kernel.callMethod( "index.vwf", "removeVideo", [ client.moniker ] );
 
     }
 
@@ -608,7 +608,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
         if ( prototypes ) {
             var len = prototypes.length;
             for ( var i = 0; i < len && !foundClient; i++ ) {
-                foundClient = ( prototypes[i] == "http-vwf-example-com-client-vwf" );    
+                foundClient = ( prototypes[i] == "http://vwf.example.com/client.vwf" );
             }
         }
 
@@ -616,7 +616,7 @@ define( [ "module", "vwf/view", "vwf/utility", "vwf/utility/color", "jquery" ], 
     }
 
     function isClientInstanceDef( nodeID ) {
-        return ( nodeID == "http-vwf-example-com-clients-vwf" );
+        return ( nodeID == "http://vwf.example.com/clients.vwf" );
     }
 
     function mediaConnection( view, peerNode ) {

--- a/support/proxy/vwf.example.com/scene.vwf.yaml
+++ b/support/proxy/vwf.example.com/scene.vwf.yaml
@@ -52,7 +52,7 @@ properties:
           }
         }
       } //@ sourceURL=scene.set.activeCamera.vwf
-    value: "http-vwf-example-com-camera-vwf-camera"
+    value: ""
 
   ## Ambient color
   ## 


### PR DESCRIPTION
This branch removes the remaining uses of legacy-format node IDs. These include:

  - Root nodes loaded from URIs, including `index.vwf`, `appscene.vwf`, and components under `http://vwf.example.com/`.
  - The child of the application named `"camera"`.

Root node IDs change as, for example:

  - `http-vwf-example-com-node3-vwf` => `http://vwf.example.com/node3.vwf`

`index-vwf` and `appscene-vwf` change to `index.vwf` and `appscene.vwf`, respectively. With `branch/absolute-application-url`, these further change to `/path/to/application/index.vwf` and `/path/to/application/appscene.vwf`.

The camera ID changes from `http-vwf-example-com-camera-vwf-camera` for type `camera.vwf` to something similar to `/path/to/application/index.vwf:n-xx-camera`, for some sequence number `n` and some randomization `xx`. (*Still to do.*)

Existing references to the legacy-format IDs should now be fixed. Attempts to parse the ID string have also been fixed. Additionally, a few remaining assumptions that the application component is `index.vwf` have also been fixed.

The camera references are a little more complicated and are still to be done.

Related changes for the applications are in `https://github.com/virtual-world-framework/vwf-apps/tree/branch/modern-ids`.

@allisoncorey @scottnc27603 @eric79 
