### PR TITLE
Fixed the sceneGetter so that it doesn't set this.scene incorrectly when called on the prototype.

### DIFF
--- a/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
+++ b/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
@@ -25,11 +25,10 @@ properties:
         //  we want to make sure that we don't incorrectly set this.scene, so 
         //  just short-circuit and return undefined.
         if ( this.scene === this ) {
-          return undefined;
-        }
-        if ( !this.scene ) {
-          this.logger.errorx( "scene.get", "Could not find scene node: '" + sp +
-                                           "'" );
+          this.scene  = undefined;
+        } else if ( !this.scene ) {
+          this.logger.errorx( "scene.get", 
+                              "Could not find scene node: '" + sp + "'" );
         }
       }
       return this.scene;

--- a/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
+++ b/support/proxy/vwf.example.com/sceneGetter.vwf.yaml
@@ -20,8 +20,16 @@ properties:
       if ( !this.scene ) {
         var sp = this.scenePath || "/";
         this.scene = this.find( sp )[ 0 ];
+        // If this is the prototype object then it will think that it is the 
+        //  scene (because it is directly attached to the root) - in that case, 
+        //  we want to make sure that we don't incorrectly set this.scene, so 
+        //  just short-circuit and return undefined.
+        if ( this.scene === this ) {
+          return undefined;
+        }
         if ( !this.scene ) {
-          this.logger.errorx( "scene.get", "Could not find scene node: '", sp, "'" );
+          this.logger.errorx( "scene.get", "Could not find scene node: '" + sp +
+                                           "'" );
         }
       }
       return this.scene;


### PR DESCRIPTION
@eric79, @davideaster 

David, Eric wanted to run this past you - the if clause that I added is being hit ~10,000 times during initialization.  Without the change, this.scene appears to get set to the object that implements sceneGetter, which then makes it impossible to get the actual scene later on.  Once initialization is done, the sceneGetter starts working correctly, so this change fixes the problem (and doesn't appear to introduce any new problems - I don't think those 10,000 calls really actually need the scene).