### PR TITLE
Comment out the hammer listeners for touch. Causes a problem in IE11.

### DIFF
--- a/support/client/lib/vwf/view/threejs.js
+++ b/support/client/lib/vwf/view/threejs.js
@@ -1647,13 +1647,13 @@ define( [ "module", "vwf/view", "vwf/utility", "hammer", "jquery" ], function( m
         // Do not emulate mouse events on touch
         Hammer.NO_MOUSEEVENTS = true;
 
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("touch release", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("hold tap doubletap", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("drag dragstart dragend dragup dragdown dragleft dragright", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("swipe swipeup swipedown swipeleft,swiperight", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("transform transformstart transformend", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("rotate", self.handleHammer);
-        $(canvas).hammer({ drag_lock_to_axis: false }).on("pinch pinchin pinchout", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("touch release", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("hold tap doubletap", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("drag dragstart dragend dragup dragdown dragleft dragright", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("swipe swipeup swipedown swipeleft,swiperight", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("transform transformstart transformend", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("rotate", self.handleHammer);
+        // $(canvas).hammer({ drag_lock_to_axis: false }).on("pinch pinchin pinchout", self.handleHammer);
 
         canvas.onmousedown = function( e ) {
 


### PR DESCRIPTION
@kadst43 

The hammer.js canvas listeners cause an issue with IE11, preventing the blockly interface from opening. It seems that IE11 registers mouse clicks as touch events as well, which has some bugs in the mars-game-staging branch.

This implementation has been updated in development, along with some default navigation fixes (ie. the middle mouse wheel zoom from the helicam view should be fixed in current development). However, commenting out these hammer listeners is a quick fix since you're not using a touch interface.

The only other problem I noticed while running in IE11 is the rover dialog interface in the bottom left corner of the screen. I am only seeing the yellow action text, not the dialog or sound from the rover. However, functionally, the app seems to be working well. 