### PR TITLE
Reload when the connection drops instead of reconnection + `setState`.

### DIFF
--- a/support/client/lib/vwf.js
+++ b/support/client/lib/vwf.js
@@ -846,6 +846,11 @@
 
                     secure: window.location.protocol === "https:",
 
+                    // Don't attempt to reestablish lost connections. The client reloads after a
+                    // disconnection to recreate the application from scratch.
+
+                    reconnect: false,
+
                 };
 
                 if ( isSocketIO07() ) {
@@ -968,6 +973,10 @@
                 socket.on( "disconnect", function() {
 
                     vwf.logger.infox( "-socket", "disconnected" );
+
+                    // Reload to rejoin the application.
+
+                    window.location = window.location.href;
 
                 } );
 


### PR DESCRIPTION
Ideally restoring the socket.io connection and processing the `setState`
would resync properly, but:

  - `setState` doesn't replicate deletions yet.

  - There's a greater chance of error if drivers don't handle all of the
    changes correctly.

  - The ruby socket.io doesn't correctly implement the protocol for a
    client to reconnect using its original ID.