### PR TITLE
Update models directory paths in admin files for both servers. 

### DIFF
--- a/lib/nodejs/admin.js
+++ b/lib/nodejs/admin.js
@@ -174,13 +174,13 @@ function HandleAdminInstances( request, response, parsedRequest ) {
 // returns false.
 function HandleAdminModels( request, response ) {
     if ( request.method == "GET" ) {
-        var filenames = fs.readdirSync( "." + libpath.sep + "public" + libpath.sep + "models" + libpath.sep );
+        var filenames = fs.readdirSync( "." + libpath.sep + "public" + libpath.sep + "demos" + libpath.sep +"models" + libpath.sep );
         var data = [];
         for ( var i in filenames ) {
             var filedata = {};
-            var filedetails = fs.statSync( "." + libpath.sep + "public" + libpath.sep + "models" + libpath.sep + filenames[ i ] );
+            var filedetails = fs.statSync( "." + libpath.sep + "public" + libpath.sep + "demos" + libpath.sep + "models" + libpath.sep + filenames[ i ] );
             if ( filedetails.isFile( ) ) {
-                filedata[ 'url' ] = "http://" + request.headers.host + "/models/" + filenames[ i ];
+                filedata[ 'url' ] = "http://" + request.headers.host + "/demos/models/" + filenames[ i ];
                 filedata[ 'basename' ] = filenames[ i ];
                 filedata[ 'size' ] = filedetails.size;
                 filedata[ 'mtime' ] = filedetails.mtime.toGMTString( );

--- a/lib/vwf/application/admin.rb
+++ b/lib/vwf/application/admin.rb
@@ -105,7 +105,7 @@ class VWF::Application::Admin < Sinatra::Base
 
   get "/models" do
     directory = Rack::Directory.new('public')
-    directory._call({'SCRIPT_NAME'=>request.scheme+'://'+request.host_with_port, 'PATH_INFO'=>'models'})
+    directory._call({'SCRIPT_NAME'=>request.scheme+'://'+request.host_with_port, 'PATH_INFO'=>'demos/models'})
     dirContents = directory.list_directory[2].files
     dirContents.map do |dirContent|
       if dirContent[3] != "" && dirContent[3] != "directory"


### PR DESCRIPTION
@davideaster 

This fixes the admin/models functionality (although the drag and drop in sandtable does not work - this is a legacy issue). We'll need to do the same for load/save functionality in the users tab. 