### PR TITLE
Blockly set max blocks before loading toolbox

### DIFF
--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -251,6 +251,12 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                             // If the new active node is different than the old,
                             // then we need to load its program into the toolbox
                             if ( show ) {
+                                if ( Blockly.mainWorkspace ) {
+                                    Blockly.mainWorkspace.maxBlocks = blocklyNode.ramMax;
+                                } else {
+                                    console.log("Blockly.mainWorkspace not found!");
+                                }
+
                                 if ( blocklyNode.toolbox !== undefined ) {
                                     loadToolbox( blocklyNode.toolbox );    
                                 } else if ( app.toolbox !== undefined ) {
@@ -261,6 +267,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                                 } else if ( app.defaultXml !== undefined ) {
                                     loadDefaultXml( app.defaultXml ); 
                                 }                               
+                                
                                 this.state.blockly.node = blocklyNode;
                                 setBlockXML( blocklyNode );
                                 setBlocklyUIVisibility( blocklyNode, true );


### PR DESCRIPTION
This should fix the "ram grayout" bug for Mars Game.

The bug (prior to this fix) can be reproduced by:
1) Starting Mars Game on mars-game-development
2) Opening the Blockly window - this should put us on Scenario 1b.
3) Switching to the dummy scenario. 
4) Scrolling down to the dummy procedure, which is grayed out, even though it shouldn't be:

![blockly_grayout](https://cloud.githubusercontent.com/assets/5407450/6567699/678a055a-c6a2-11e4-9b5c-c3be5b093b01.png)

(This patch should fix the above). 
