### PR TITLE
Branch/open blockly interface

### DIFF
--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -232,45 +232,30 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                         // If the new node is the same as the old - exit early to prevent 
                         // breaking synchronization.
 
-                        if ( previousActiveNode === newActiveNodeId ) {
+                        if ( previousActiveNode === blocklyNode ) {
                             break;
                         }
 
+                        if ( previousActiveNode !== undefined ) {
+                            getBlockXML( previousActiveNode );
+                            this.state.blockly.node = undefined;
+                        }
+
                         if ( blocklyNode !== undefined ) {
-                            var show = true;
-
-                            //If there was already an active blockly node, deal with it before
-                            //activating the new one
-                            if ( previousActiveNode !== undefined ) {
-                               getBlockXML( previousActiveNode );
-                               setBlocklyUIVisibility( previousActiveNode, false ); 
-                               show = ( previousActiveNode.ID !== newActiveNodeId );
-                               this.state.blockly.node = undefined;                           
-                            }
-
                             // If the new active node is different than the old,
                             // then we need to load its program into the toolbox
-                            if ( show ) {
-                                if ( blocklyNode.toolbox !== undefined ) {
-                                    loadToolbox( blocklyNode.toolbox );    
-                                } else if ( app.toolbox !== undefined ) {
-                                    loadToolbox( app.toolbox );
-                                }
-                                if ( blocklyNode.defaultXml !== undefined ) {
-                                    loadDefaultXml( blocklyNode.defaultXml );    
-                                } else if ( app.defaultXml !== undefined ) {
-                                    loadDefaultXml( app.defaultXml ); 
-                                }                               
-                                this.state.blockly.node = blocklyNode;
-                                setBlockXML( blocklyNode );
-                                setBlocklyUIVisibility( blocklyNode, true );
-                            }                        
-                        } else {
-                            if ( previousActiveNode !== undefined ) {
-                                getBlockXML( previousActiveNode );
-                                setBlocklyUIVisibility( previousActiveNode, false );
-                                this.state.blockly.node = undefined;                            
-                            } 
+                            if ( blocklyNode.toolbox !== undefined ) {
+                                loadToolbox( blocklyNode.toolbox );
+                            } else if ( app.toolbox !== undefined ) {
+                                loadToolbox( app.toolbox );
+                            }
+                            if ( blocklyNode.defaultXml !== undefined ) {
+                                loadDefaultXml( blocklyNode.defaultXml );
+                            } else if ( app.defaultXml !== undefined ) {
+                                loadDefaultXml( app.defaultXml );
+                            }
+                            this.state.blockly.node = blocklyNode;
+                            setBlockXML( blocklyNode );
                         }
                         break;
 

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -256,6 +256,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                             }
                             this.state.blockly.node = blocklyNode;
                             setBlockXML( blocklyNode );
+                            this.kernel.fireEvent( blocklyNode.ID, "blocklyVisibleChanged", [ getBlocklyUIVisibility() ] );
                         }
                         break;
 
@@ -391,6 +392,12 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
         if ( node && node.ID ) {
             self.kernel.fireEvent( node.ID, "blocklyVisibleChanged", [ show ] );
         }
+    }
+
+    function getBlocklyUIVisibility() {
+        var div = document.getElementById( self.options.divParent );
+        var result = div.style.visibility === "visible" ? true : false;
+        return result;
     }
 
     function loadToolbox( toolboxDef ) {

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -388,7 +388,9 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
             self.delayedProperties = undefined;
         }
 
-        self.kernel.fireEvent( node.ID, "blocklyVisibleChanged", [ show ] );
+        if ( node && node.ID ) {
+            self.kernel.fireEvent( node.ID, "blocklyVisibleChanged", [ show ] );
+        }
     }
 
     function loadToolbox( toolboxDef ) {

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -276,6 +276,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                             this.delayedProperties.blockly_autoClose = Boolean( propertyValue );
                         }
                         break;
+
+                    case "blockly_interfaceVisible":
+                        setBlocklyUIVisibility( this.state.blockly.node, propertyValue );
+                        break;
                 }
 
             } else if ( this.state.blockly.node && ( nodeID === this.state.blockly.node.ID ) ) {

--- a/support/proxy/vwf.example.com/blockly/manager.vwf.yaml
+++ b/support/proxy/vwf.example.com/blockly/manager.vwf.yaml
@@ -24,6 +24,7 @@ properties:
   blockly_toolbox:
   blockly_defaultXml:
   blockly_autoClose:
+  blockly_interfaceVisible:
 methods:
   startAllExecution:
   stopAllExecution:


### PR DESCRIPTION
@kadst43 @AmbientOSX @scottnc27603 
- Added `blockly_interfaceVisible` property to handle showing and hiding the Blockly UI.
- Fixed and refactored some code.

Used by: https://github.com/virtual-world-framework/mars-game/pull/509
