### PR TITLE
Branch/collada transparency fix

### DIFF
--- a/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
+++ b/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
@@ -3577,6 +3577,7 @@ THREE.ColladaLoader = function () {
 				case 'emission':
 				case 'diffuse':
 				case 'specular':
+				case 'specularLevel':
 				case 'transparent':
 
 					this[ child.nodeName ] = ( new ColorOrTexture() ).parse( child );
@@ -3666,6 +3667,7 @@ THREE.ColladaLoader = function () {
 			'diffuse':'map',
 			'ambient':'lightMap' ,
 			'specular':'specularMap',
+			'specularLevel':'specularMap',
 			'emission':'emissionMap',
 			'bump':'bumpMap',
 			'normal':'normalMap'
@@ -3679,6 +3681,7 @@ THREE.ColladaLoader = function () {
 				case 'emission':
 				case 'diffuse':
 				case 'specular':
+				case 'specularLevel':
 				case 'bump':
 				case 'normal':
 

--- a/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
+++ b/support/client/lib/vwf/model/threejs/js/loaders/ColladaLoader.js
@@ -1153,7 +1153,7 @@ THREE.ColladaLoader = function () {
 
 						}
 
-						material3js.opacity = !material3js.opacity ? 1 : material3js.opacity;
+						material3js.opacity = material3js.opacity === undefined ? 1 : material3js.opacity;
 						used_materials[ instance_material.symbol ] = num_materials;
 						used_materials_array.push( material3js );
 						first_material = material3js;
@@ -3633,20 +3633,33 @@ THREE.ColladaLoader = function () {
 
 		var props = {};
 
-		var transparent = false;
-
-		if (this['transparency'] !== undefined && this['transparent'] !== undefined) {
+		if ( this[ 'transparency' ] !== undefined && this[ 'transparent' ] !== undefined ) {
 			// convert transparent color RBG to average value
-			var transparentColor = this['transparent'];
-			var transparencyLevel = (this.transparent.color.r + this.transparent.color.g + this.transparent.color.b) / 3 * this.transparency;
-
-			if (transparencyLevel > 0) {
-				transparent = true;
-				props[ 'transparent' ] = true;
-				props[ 'opacity' ] = 1 - transparencyLevel;
-
+			var transparentColor = this[ 'transparent' ];
+			var transparencyLevel = 0;
+			// Determine transparency level based on opaque mode
+			if ( transparentColor.opaque == "RGB_ONE" ) {
+				transparencyLevel = ( 3 - this.transparent.color.r -
+					this.transparent.color.g -
+					this.transparent.color.b ) /
+					3 * this.transparency;
+			} else if ( transparentColor.opaque == "RGB_ZERO" ) {
+				transparencyLevel = ( this.transparent.color.r +
+					this.transparent.color.g +
+					this.transparent.color.b ) /
+					3 * this.transparency;
+			} else if ( transparentColor.opaque == "A_ONE" ) {
+				transparencyLevel = ( 1 - this.transparent.color.a ) * this.transparency;
+			} else { // A_ZERO (default in collada 1.5.0) - http://www.khronos.org/files/collada_1_5_release_notes.pdf (pg 16)
+				transparencyLevel = this.transparent.color.a * this.transparency;
 			}
-
+			// Assumes all texures in the 'transparent' field will have an alpha channel
+			if ( transparentColor.isTexture() || transparencyLevel > 0 ) {
+				props[ 'transparent' ] = true;
+			} else {
+				props[ 'transparent' ] = false;
+			}
+			props[ 'opacity' ] = 1 - transparencyLevel;
 		}
 
 		var keys = {
@@ -3722,7 +3735,7 @@ THREE.ColladaLoader = function () {
 
 							}
 
-						} else if ( prop === 'diffuse' || !transparent ) {
+						} else {
 
 							if ( prop === 'emission' ) {
 


### PR DESCRIPTION
Re-apply old transparency mode fixes to Collada loader. The [fixes were submitted to ThreeJS here](https://github.com/mrdoob/three.js/pull/4607), but were ignored (due to some confusion or lack of understanding). All of the Collada models were being set to transparent by the loader causing them all to be sorted as transparent objects which is why we were getting the clipping on the particles and tracks in mars-game. We should probably continue to look for a Collada alternative as support for it in ThreeJS isn't great and we will keep having to apply these fixes if we update to the latest ThreeJS. @scottnc27603 It might be useful to apply these fixes to the core as well and have them saved for later.

Fixes in this branch:
- Properly set the transparent value in the Collada loader
- Fixes specular, ambient, and other properties being set on transparent objects
- Allows a specular map to be defined by the `specularLevel` node that 3DSMax uses

Hopefully this is the last time I have to fix this.
@kadst43 @nmarshak1337 @AmbientOSX 
