### PR TITLE
Add an unknown unit symbol type to mil-sym.

### DIFF
--- a/support/client/lib/mil-sym/cws.js
+++ b/support/client/lib/mil-sym/cws.js
@@ -1194,6 +1194,14 @@ define( function(){
             "ZOR": "ZONE OF RESPONSIBILITY (ZOR)"
         },
 
+        "unk": {
+
+            "WAR.UNK": {
+                "symbolID": "SUZP------*****", 
+                "tag": "UNK"   
+            }
+        },
+
         "space": {
 
             "WAR.SPC": {


### PR DESCRIPTION
Simple change.  Just add an unknown unit symbol.
TBS staff wanted to be able to place an unknown unit type/echelon.  This complies with Mil-Std 2525 and is supported by the Mil-Sym library.

@scottnc27603 
