### PR TITLE
Branch/shader material support

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -5587,6 +5587,13 @@ define( [ "module",
                 obj[ prop ].src = value;
                 obj[ prop ].value = loadTexture( undefined, value );
                 break;
+            case 'tv':
+                var textureArray = [];
+                for ( var i = 0; i < value.length; i++ ) {
+                    textureArray.push( loadTexture( undefined, value[ i ] ) );
+                }
+                obj[ prop ].value = textureArray;
+                break;
         } 
     
     }
@@ -5616,6 +5623,12 @@ define( [ "module",
                     result = loadTexture( undefined, value );
                 }
                 break;
+            case 'tv':
+                result = [];
+                for ( var i = 0; i < value.length; i++ ) {
+                    result.push( loadTexture( undefined, value[ i ] ) );
+                }
+                break;
         }
         return result;
     }
@@ -5635,6 +5648,7 @@ define( [ "module",
         var txt = undefined;
         var url = undefined;
         var mapping = undefined;
+        var wrapTexture = false;
         var onLoad = function( texture ) {
             if ( mat ) {
                 mat.map = texture;
@@ -5653,6 +5667,7 @@ define( [ "module",
         } else {
             url = def.url;
             mapping = def.mapping;
+            wrapTexture = Boolean( def.wrapTexture );
         }
 
         if ( mat === undefined ) {
@@ -5663,6 +5678,10 @@ define( [ "module",
             }
         } else {
             txt = THREE.ImageUtils.loadTexture( url, mapping, onLoad, onError );            
+        }
+
+        if ( wrapTexture ) {
+            txt.wrapS = txt.wrapT = THREE.RepeatWrapping;
         }
 
         return txt;

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1655,6 +1655,10 @@ define( [ "module",
                                 eval( this.updateFunction );
                             }
                         }
+                        if ( propertyName === "lights" ) {
+                            value = propertyValue;
+                            threeObject.lights = value;
+                        }
                     }
                 }
                 if ( node.isUniformObject ) {

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1608,7 +1608,7 @@ define( [ "module",
                         }
                     }
                 }
-                if ( threeObject instanceof THREE.Material ) {
+                if ( threeObject instanceof THREE.Material && !( threeObject instanceof THREE.ShaderMaterial ) ) {
 
                     value = setMaterialProperty( threeObject, propertyName, propertyValue );
 
@@ -1639,25 +1639,23 @@ define( [ "module",
                         if ( propertyName === "uniforms" ) {
                             value = propertyValue;
                             threeObject.uniforms = value;
-                        }
-                        if ( propertyName === "vertexShader" ) {
+                        } else if ( propertyName === "vertexShader" ) {
                             value = propertyValue;
                             threeObject.vertexShader = value;
-                        }
-                        if ( propertyName === "fragmentShader" ) {
+                        } else if ( propertyName === "fragmentShader" ) {
                             value = propertyValue;
                             threeObject.fragmentShader = value;
-                        }
-                        if ( propertyName === "updateFunction" ) {
+                        } else if ( propertyName === "updateFunction" ) {
                             value = propertyValue;
                             threeObject.updateFunction = value;
                             threeObject.update = function() {
                                 eval( this.updateFunction );
                             }
-                        }
-                        if ( propertyName === "lights" ) {
+                        } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
+                        } else if ( !threeObject.hasOwnProperty( propertyName ) ) {
+                            threeObject[ propertyName ] = propertyValue;
                         }
                     }
                 }

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1654,7 +1654,7 @@ define( [ "module",
                         } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
-                        } else if ( !threeObject.hasOwnProperty( propertyName ) ) {
+                        } else {
                             threeObject[ propertyName ] = propertyValue;
                         }
                     }


### PR DESCRIPTION
Fixed some issues with shader material components. The uniforms list was being passed by reference, so multiple materials extending the same shader material component were overwriting each other. To fix this, I made it so that the uniforms list is copied in the driver when a node is created, so a new uniforms object is created instead of using the reference of the old one. I added the function `getUniformValueByType` to assist in initializing the shader values in the uniforms list to the appropriate type. There are many more types that should probably be handled, but I haven't had a use case that compelled me to do it.

I also made it so that you can change the value of a uniform by simply setting a property of the same name on the node. If that property name is not handled sooner (if it is named `vertexShader`, for instance, it will not reach the uniform setting conditional. Obviously uniforms should be named uniquely). The uniforms list creates the uniforms on the shader material `threeObject` and the properties allow you to set the value without having to set the type or use the `this.uniforms.property.value` syntax.

Additionally, I needed a way to store data on the `threeObject` itself for use in the `updateFunction`. To do this, I made it so that properties starting with an underscore (`_time` for instance) are stored on the `threeObject`. The only other way was to set them as uniforms, which isn't a good way to do it.

I also added the ability to set the `lights` property on a shader material so that three js will pass the light data to it. There are probably more material properties that should be exposed in the same way.

So far, this is the best way I could think of to accomplish all of this and it works very well so far. The VWF node/component model doesn't innately handle the complexity of shader materials well, so a lot of this feels somewhat hacky, but it's necessary in order to expose all of the options to developers.

@kadst43 @AmbientOSX 

@scottnc27603 @eric79 This is going into the mars-game branch for now, but with the intent to eventually make it to development, so if you want to look over it, that would be good.
