### PR TITLE
Fix For Toolbox Setting When Switching Missions

### DIFF
--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -232,7 +232,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                         // If the new node is the same as the old - exit early to prevent 
                         // breaking synchronization.
 
-                        if ( previousActiveNode === blocklyNode ) {
+                        if ( previousActiveNode && blocklyNode && previousActiveNode === blocklyNode ) {
                             setBlockXML( blocklyNode );
                             break;
                         }


### PR DESCRIPTION
The error was caused when `previousActiveNode` and `blocklyNode` were both undefined or null. For some reason, the error being generated in setBlockXML was causing the blocks to never update. This is consistent with what I've seen in JavaScript in that when something breaks somewhere, that piece of code stops working altogether.

@kadst43 @AmbientOSX 
