### PR TITLE
Canvas Textures

### DIFF
--- a/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
+++ b/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
@@ -35,3 +35,6 @@ methods:
       var defines = this.defines;
       defines[ name ] = value;
       this.defines = defines;
+  updateTexture:
+    parameters:
+      - textureName


### PR DESCRIPTION
@kadst43 @AmbientOSX 
- Adds ability to set a `canvasID` in a texture uniform to use a 2d canvas as a texture
- Adds ability to set various texture properties when initializing texture uniforms
