### PR TITLE
Fix for extending heightmap

### DIFF
--- a/support/client/lib/vwf/model/heightmap.js
+++ b/support/client/lib/vwf/model/heightmap.js
@@ -25,7 +25,7 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                 var node = this.nodes[ childID ];
 
                 // Create the local copy of the node properties
-                if ( this.nodes[ childID ] === undefined ){
+                if ( this.nodes[ childID ] === undefined && childSource !== undefined ){
 
                     // Suspend the queue until the load is complete
                     callback( false );


### PR DESCRIPTION
@kadst43 @AmbientOSX 

This fix allows heightmap.vwf to be extended by preventing it from trying to load an image on component definitions. This was causing an error in the heightmap driver which was preventing the extending node from being able to fully initialize. This is required for the grid changes that I will be submitting shortly in mars-game.
