### PR TITLE
branch/hud-draw-order

### DIFF
--- a/support/client/lib/vwf/model/hud.js
+++ b/support/client/lib/vwf/model/hud.js
@@ -47,7 +47,8 @@ define( [ "module", "vwf/model", "vwf/utility" ], function( module, model, utili
                         "alignH": undefined,
                         "alignV": undefined,
                         "offsetH": undefined,
-                        "offsetV": undefined
+                        "offsetV": undefined,
+                        "drawOrder": undefined
                     },
                     "drawProperties": {},
                     "initialized": false

--- a/support/client/lib/vwf/view/hud.js
+++ b/support/client/lib/vwf/view/hud.js
@@ -142,7 +142,7 @@ define( [ "module", "vwf/model", "vwf/utility", "vwf/view/hud/hud" ], function( 
         for ( var i = 0; i < keys.length; i++ ) {
             element = node.elements[ keys[ i ] ];
             props = element.properties;
-            overlay.add( element.viewObject, props.alignH, props.alignV, props.offsetH, props.offsetV );
+            overlay.add( element.viewObject, props.alignH, props.alignV, props.offsetH, props.offsetV, props.drawOrder );
         }
         return overlay;
     }

--- a/support/client/lib/vwf/view/hud/hud.js
+++ b/support/client/lib/vwf/view/hud/hud.js
@@ -96,7 +96,7 @@ define( function() {
 
         },
 
-        add: function( element, alignH, alignV, offsetH, offsetV ) {
+        add: function( element, alignH, alignV, offsetH, offsetV, drawOrder ) {
 
             // Add the element to the HUD's elements list
             // Initialize the offset position
@@ -134,7 +134,12 @@ define( function() {
             }
 
             this.countElements();
-            newElement[ "drawOrder" ] = this.elementCount;
+            if ( isNaN( drawOrder ) ) {
+                newElement[ "drawOrder" ] = this.elementCount;
+            } else {
+                newElement[ "drawOrder" ] = drawOrder;
+            }
+            
         },
 
         sortFunction: function( a, b ) {

--- a/support/proxy/vwf.example.com/hud/element.vwf.yaml
+++ b/support/proxy/vwf.example.com/hud/element.vwf.yaml
@@ -9,6 +9,7 @@ properties:
   alignV:
   offsetH:
   offsetV:
+  drawOrder:
 methods:
   draw:
 events:


### PR DESCRIPTION
@kadst43 @AmbientOSX 

This allows us to define the draw order of the HUD elements in the application.
