### PR TITLE
Blockly Driver Fixes

### DIFF
--- a/support/client/lib/vwf/model/blockly.js
+++ b/support/client/lib/vwf/model/blockly.js
@@ -227,14 +227,15 @@ define( [ "module", "vwf/model", "vwf/utility",
                     case  "blockly_code":
                         value = node.code = propertyValue;
                         break;
-                    
-                    case "blockly_xml":
-                        if ( propertyValue.indexOf('http://www.w3.org/1999/xhtml') !== -1 ) {
-                           //SJF: Invalid XML being passed in as default on Blockly clear sometimes
-                        } else {
+
+                    case "new_xml":
                            node.blocks = propertyValue;
                            value = propertyValue; 
-                        }
+                        break;
+
+                    case "blockly_xml":
+                           node.blocks = propertyValue;
+                           value = propertyValue; 
                         break;
 
                      case "blockly_timeBetweenLines":

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -290,13 +290,13 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                         var clientThatSetProperty = this.kernel.client();
                         var me = this.kernel.moniker();
                         if ( clientThatSetProperty !== me ) {
-                            //var xmlText = propertyValue;
+                            var xmlText = propertyValue;
                             handleChangeEvents = false;
-                            //setWorkspaceFromXmlText( xmlText, true );
+                            setWorkspaceFromXmlText( xmlText, true );
                         }
                         var xmlText = propertyValue;
                         setWorkspaceFromXmlText( xmlText, true );
-
+                        
                         break;
                     default:
                         break;
@@ -496,7 +496,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
 
     function setWorkspaceFromXmlText( xmlText, clearBeforeSet ) {
         var xmlDom = null;
-        console.log(xmlText);
+        
         try {
             xmlDom = Blockly.Xml.textToDom( xmlText );
         } catch ( e ) {

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -290,15 +290,13 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                         var clientThatSetProperty = this.kernel.client();
                         var me = this.kernel.moniker();
                         if ( clientThatSetProperty !== me ) {
-                            var xmlText = propertyValue;
+                            //var xmlText = propertyValue;
                             handleChangeEvents = false;
-                            setWorkspaceFromXmlText( xmlText, true );
-                        } else {
-                            if ( propertyValue !== undefined ) {
-                                var xmlText = propertyValue;
-                                setWorkspaceFromXmlText( xmlText, true );
-                            }
-                        } 
+                            //setWorkspaceFromXmlText( xmlText, true );
+                        }
+                        var xmlText = propertyValue;
+                        setWorkspaceFromXmlText( xmlText, true );
+
                         break;
                     default:
                         break;

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -61,7 +61,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                 if ( createBlocklyDivs ) {
                     this.state.scenes[ childID ] = {
                         "toolbox": undefined,
-                        "defaultXml": undefined
+                        "defaultXml": undefined,
                     }
 
                     if ( this.options.createButton ) {
@@ -163,6 +163,14 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                                 }
                                 self.kernel.setProperty( self.state.blockly.node.ID, "blockly_code", 
                                     Blockly.JavaScript.workspaceToCode( Blockly.getMainWorkspace() ) );
+
+                                var blocks = Blockly.mainWorkspace.getAllBlocks();
+                                var blockCount = blocks.length;
+                                var topBlockCount = Blockly.mainWorkspace.topBlocks_.length;
+                                
+                                self.kernel.fireEvent( self.kernel.application(), "blocklyContentChanged", [ true ] );
+                                self.kernel.setProperty( self.state.blockly.node.ID, "blockly_blockCount", blockCount );
+                                self.kernel.setProperty( self.state.blockly.node.ID, "blockly_topBlockCount", topBlockCount );
                             }
                             
                         }
@@ -294,9 +302,11 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                             handleChangeEvents = false;
                             setWorkspaceFromXmlText( xmlText, true );
                         }
+                        break;
+                    case "new_xml":
                         var xmlText = propertyValue;
+                        handleChangeEvents = false;
                         setWorkspaceFromXmlText( xmlText, true );
-                        
                         break;
                     default:
                         break;
@@ -364,6 +374,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
             blocksInWorkspace[ blocks[ i ].id ] = { "id": blocks[ i ].id, "type": blocks[ i ].type };
         }
 
+        self.kernel.fireEvent( self.kernel.application(), "blocklyContentChanged", [ true ] );
         self.kernel.setProperty( node.ID, "blockly_blockCount", blockCount );
         self.kernel.setProperty( node.ID, "blockly_topBlockCount", topBlockCount );     
     }

--- a/support/client/lib/vwf/view/blockly.js
+++ b/support/client/lib/vwf/view/blockly.js
@@ -293,7 +293,12 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
                             var xmlText = propertyValue;
                             handleChangeEvents = false;
                             setWorkspaceFromXmlText( xmlText, true );
-                        }
+                        } else {
+                            if ( propertyValue !== undefined ) {
+                                var xmlText = propertyValue;
+                                setWorkspaceFromXmlText( xmlText, true );
+                            }
+                        } 
                         break;
                     default:
                         break;
@@ -493,13 +498,14 @@ define( [ "module", "vwf/view", "jquery", "vwf/model/blockly/JS-Interpreter/acor
 
     function setWorkspaceFromXmlText( xmlText, clearBeforeSet ) {
         var xmlDom = null;
+        console.log(xmlText);
         try {
             xmlDom = Blockly.Xml.textToDom( xmlText );
         } catch ( e ) {
-            var q = window.confirm( "XML is invalid" );
-            if ( !q ) {
-                return;
-            }
+            //var q = window.confirm( "XML is invalid" );
+            //if ( !q ) {
+            //    return;
+            //}
         }
         if ( xmlDom ) {
             clearBeforeSet && Blockly.mainWorkspace.clear();


### PR DESCRIPTION
@kadst43 @BrettASwift Replication was causing calls to set blockly_xml to either be repeated endlessly or not work at all because of the "moniker" or sender that had made the change. SatProperty is where we update the workspace so we needed a way, outside of the synchronized-safe code to do this update. Setting new_xml accomplishes this. Supports upcoming Mars Game side PR
