### PR TITLE
Reset internal array when uniform length changes

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -5644,6 +5644,9 @@ define( [ "module",
                     vectorArray.push( new THREE.Vector2( vector[0], vector[1] ) );
                 }
                 obj[ prop ].value = vectorArray;
+                if ( obj[ prop ]._array && obj[ prop ]._array.length !== vectorArray.length * 2 ) {
+                    obj[ prop ]._array = undefined;
+                }
                 break;
             case 'iv1':
                 var intArray = [];


### PR DESCRIPTION
@kadst43 

The array of values that is passed to the shader by threejs is created once and has a fixed length. Threejs does not check if the value length changes. This will reset the array when the uniform value length has changed so threejs will recreate it with the proper length.
