### PR TITLE
Fix HUD Event Disabling

### DIFF
--- a/support/client/lib/vwf/view/hud/hud.js
+++ b/support/client/lib/vwf/view/hud/hud.js
@@ -215,29 +215,27 @@ define( function() {
         },
 
         handleEvent: function( event ) {
+            var type;
+            switch ( event.type ) {
+                case "click":
+                    type = "onClick";
+                    break;
+                case "mouseup":
+                    type = "onMouseUp";
+                    break;
+                case "mousedown":
+                    type = "onMouseDown";
+                    break;
+                case "mousemove":
+                    type = "onMouseMove";
+                    break;
+                default:
+                    console.log( "HUD.handleEvent - Unhandled event type: " + event.type );
+                    return;
+            }
             if ( this.enabled ) {
                 this.pick( event );
                 var topPick = this.picks[ 0 ];
-                var type;
-
-                switch ( event.type ) {
-                    case "click":
-                        type = "onClick";
-                        break;
-                    case "mouseup":
-                        type = "onMouseUp";
-                        break;
-                    case "mousedown":
-                        type = "onMouseDown";
-                        break;
-                    case "mousemove":
-                        type = "onMouseMove";
-                        break;
-                    default:
-                        console.log( "HUD.handleEvent - Unhandled event type: " + event.type );
-                        return;
-                }
-
                 if ( topPick ) {
                     if ( topPick.enabled ) {
                         this.elements[ topPick.id ][ type ]( event );


### PR DESCRIPTION
@kadst43 @AmbientOSX 

So, remember how I said I didn't remember disabling the camera when the HUD was disabled? Well, I was right, sort of. I accidentally referenced the `type` variable out of scope in the code that I changed here, which caused the else condition to fail. What it should do, and what it now does, is when the HUD is disabled, it uses the default event of the game canvas, which is navigation.

This is just one of those things that broke quietly and because it resulted in a change we thought we wanted, it never drew any attention. A happy/unhappy coincidence.

Just to be perfectly clear, this change re-enables the camera movement during mission VO.
