### PR TITLE
Shader Material Support Improvements

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1655,6 +1655,10 @@ define( [ "module",
                                 eval( this.updateFunction );
                             }
                         }
+                        if ( propertyName === "lights" ) {
+                            value = propertyValue;
+                            threeObject.lights = value;
+                        }
                     }
                 }
                 if ( node.isUniformObject ) {

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1635,9 +1635,20 @@ define( [ "module",
                 if ( threeObject instanceof THREE.ShaderMaterial ) {
                     
                     if ( utility.validObject( propertyValue ) ) {
-                        
                         if ( propertyName === "uniforms" ) {
-                            value = propertyValue;
+                            // Copy uniforms to prevent uniforms being shared across shaders
+                            var names = Object.keys( propertyValue );
+                            var uniforms = {};
+                            for ( var i = 0; i < names.length; i++ ) {
+                                var type, value;
+                                type = propertyValue[ names[ i ] ].type;
+                                value = propertyValue[ names[ i ] ].value;
+                                uniforms[ names[ i ] ] = {
+                                    "type": type,
+                                    "value": getUniformValueByType( type, value )
+                                }
+                            }
+                            value = uniforms;
                             threeObject.uniforms = value;
                         } else if ( propertyName === "vertexShader" ) {
                             value = propertyValue;
@@ -1654,7 +1665,10 @@ define( [ "module",
                         } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
-                        } else {
+                        } else if ( threeObject.uniforms.hasOwnProperty( propertyName ) ) {
+                            var type = threeObject.uniforms[ propertyName ].type;
+                            setUniformProperty( threeObject.uniforms, propertyName, type, propertyValue );
+                        } else if ( propertyName.indexOf("_") === 0 ) {
                             threeObject[ propertyName ] = propertyValue;
                         }
                     }
@@ -5551,6 +5565,35 @@ define( [ "module",
                 break;
         } 
     
+    }
+    function getUniformValueByType( type, value ) {
+        var result = value;
+        switch ( type ) {
+            case 'i':
+                result = Number( value );
+                break
+            case 'f':
+                result = parseFloat( value );
+                break;
+            case 'c':
+                result = new THREE.Color( value );
+                break;
+            case 'v2':
+                result = new THREE.Vector2( value[0], value[1] );
+                break;
+            case 'v3':
+                result = new THREE.Vector3( value[0], value[1], value[2] );
+                break;
+            case 'v4':
+                result = new THREE.Vector4( value[0], value[1], value[2], value[3] );
+                break;
+            case 't':
+                if ( value ) {
+                    result = loadTexture( undefined, value );
+                }
+                break;
+        }
+        return result;
     }
     function decompress(dataencoded)
     {

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1608,7 +1608,7 @@ define( [ "module",
                         }
                     }
                 }
-                if ( threeObject instanceof THREE.Material ) {
+                if ( threeObject instanceof THREE.Material && !( threeObject instanceof THREE.ShaderMaterial ) ) {
 
                     value = setMaterialProperty( threeObject, propertyName, propertyValue );
 
@@ -1639,25 +1639,23 @@ define( [ "module",
                         if ( propertyName === "uniforms" ) {
                             value = propertyValue;
                             threeObject.uniforms = value;
-                        }
-                        if ( propertyName === "vertexShader" ) {
+                        } else if ( propertyName === "vertexShader" ) {
                             value = propertyValue;
                             threeObject.vertexShader = value;
-                        }
-                        if ( propertyName === "fragmentShader" ) {
+                        } else if ( propertyName === "fragmentShader" ) {
                             value = propertyValue;
                             threeObject.fragmentShader = value;
-                        }
-                        if ( propertyName === "updateFunction" ) {
+                        } else if ( propertyName === "updateFunction" ) {
                             value = propertyValue;
                             threeObject.updateFunction = value;
                             threeObject.update = function() {
                                 eval( this.updateFunction );
                             }
-                        }
-                        if ( propertyName === "lights" ) {
+                        } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
+                        } else if ( !threeObject.hasOwnProperty( propertyName ) ) {
+                            threeObject[ propertyName ] = propertyValue;
                         }
                     }
                 }

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -677,7 +677,7 @@ define( [ "module",
                                             objectDef[ prop ] = propertyValue[ prop ];
                                             break;    
                                     }
-                                }   
+                                }
                             }
 
                             node.threeObject = createMaterial( objectDef );
@@ -1650,6 +1650,13 @@ define( [ "module",
                             }
                             value = uniforms;
                             threeObject.uniforms = value;
+                        } else if ( propertyName === "defines" ) {
+                            var names = Object.keys( propertyValue );
+                            var defines = {};
+                            for ( var i = 0; i < names.length; i++ ) {
+                                defines[ names[ i ] ] = propertyValue[ names[ i ] ];
+                            }
+                            threeObject.defines = defines;
                         } else if ( propertyName === "vertexShader" ) {
                             value = propertyValue;
                             threeObject.vertexShader = value;
@@ -1668,8 +1675,14 @@ define( [ "module",
                         } else if ( threeObject.uniforms.hasOwnProperty( propertyName ) ) {
                             var type = threeObject.uniforms[ propertyName ].type;
                             setUniformProperty( threeObject.uniforms, propertyName, type, propertyValue );
+                        // -----------
+                        // TODO: Defines are constants within the shader, do they need to be set in this way?
+                        // } else if ( threeObject.defines.hasOwnProperty( propertyName ) ) {
+                        //     value = propertyValue;
+                        //     threeObject.defines[ propertyName ] = value;
                         } else if ( propertyName.indexOf("_") === 0 ) {
-                            threeObject[ propertyName ] = propertyValue;
+                            value = propertyValue;
+                            threeObject[ propertyName ] = value;
                         }
                     }
                 }
@@ -2255,6 +2268,13 @@ define( [ "module",
                         } else {
                             value[ uni ] = threeObject.uniforms[ uni ];     
                         }
+                    }
+                    return value;
+                }
+                if ( propertyName === "defines" ) {
+                    value = {};
+                    for ( var def in threeObject.defines ) {
+                        value[ def ] = threeObject.defines[ def ];
                     }
                     return value;
                 }
@@ -5570,6 +5590,15 @@ define( [ "module",
                 }
                 obj[ prop ].value = textureArray;
                 break;
+            case 'v2v':
+                var vectorArray = [];
+                var vector;
+                for ( var i = 0; i < value.length; i++ ) {
+                    vector = value[ i ];
+                    vectorArray.push( new THREE.Vector2( vector[0], vector[1] ) );
+                }
+                obj[ prop ].value = vectorArray;
+                break;
         } 
     
     }
@@ -5603,6 +5632,14 @@ define( [ "module",
                 result = [];
                 for ( var i = 0; i < value.length; i++ ) {
                     result.push( loadTexture( undefined, value[ i ] ) );
+                }
+                break;
+            case 'v2v':
+                result = [];
+                var vector;
+                for ( var i = 0; i < value.length; i++ ) {
+                    vector = value[ i ];
+                    result.push( new THREE.Vector2( vector[0], vector[1] ) );
                 }
                 break;
         }

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -5626,6 +5626,9 @@ define( [ "module",
                     vectorArray.push( new THREE.Vector2( vector[0], vector[1] ) );
                 }
                 obj[ prop ].value = vectorArray;
+                if ( obj[ prop ]._array && obj[ prop ]._array.length !== vectorArray.length * 2 ) {
+                    obj[ prop ]._array = undefined;
+                }
                 break;
             case 'iv1':
                 var intArray = [];

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -2631,6 +2631,16 @@ define( [ "module",
 
         callingMethod: function( nodeID, methodName, parameters /* [, parameter1, parameter2, ... ] */ ) { // TODO: parameters
 
+            var node = this.state.nodes[ nodeID ];
+            if ( !node ) {
+                node = this.state.scenes[ nodeID ];
+            }
+
+            var threeObject;
+            if ( node ) {
+                threeObject = node.threeObject || node.threeScene;
+            }
+
             if ( methodName === "raycast" ) {
 
                 var origin, direction, near, far, recursive, objectIDs;
@@ -2738,6 +2748,20 @@ define( [ "module",
                 var intersects = raycaster.intersectObjects( objects, recursive );
                 return intersects;
 
+            }
+
+            if ( threeObject instanceof THREE.ShaderMaterial ) {
+                if ( methodName === "updateTexture" ) {
+                    var textureName = parameters[ 0 ];
+                    var texture = threeObject.uniforms[ textureName ];
+                    if ( texture ) {
+                        texture.value.needsUpdate = true;
+                        threeObject.needsUpdate = true;
+                    } else {
+                        this.logger.warnx( nodeID + ".updateTexture", "Texture \""
+                            + textureName + "\" not found!" );
+                    }
+                }
             }
 
             return undefined;
@@ -5684,14 +5708,21 @@ define( [ "module",
         //console.log( [ "loadTexture: ", JSON.stringify( def ) ] );
 
         if ( utility.isString( def ) ) {
-            url = def;    
+            url = def;
         } else {
-            url = def.url;
+            if ( def.canvasID ) {
+                var canvas = document.getElementById( def.canvasID );
+                url = canvas;
+            } else {
+                url = def.url;
+            }
             mapping = def.mapping;
             wrapTexture = Boolean( def.wrapTexture );
         }
 
-        if ( mat === undefined ) {
+        if ( url instanceof HTMLElement && url.nodeName === "CANVAS" ) {
+            txt = new THREE.Texture( url );
+        } else if ( mat === undefined ) {
             if ( mapping === undefined ) {
                 txt = THREE.ImageUtils.loadTexture( url );    
             } else {
@@ -5699,6 +5730,13 @@ define( [ "module",
             }
         } else {
             txt = THREE.ImageUtils.loadTexture( url, mapping, onLoad, onError );            
+        }
+
+        if ( def instanceof Object ) {
+            var keys = Object.keys( def );
+            for ( var i = 0; i < keys.length; i++ ) {
+                setTextureProperty( txt, keys[ i ], def[ keys[ i ] ], true );
+            }
         }
 
         if ( wrapTexture ) {
@@ -5934,7 +5972,7 @@ define( [ "module",
         return value;
     }
 
-    function setTextureProperty( texture, propertyName, propertyValue ) {
+    function setTextureProperty( texture, propertyName, propertyValue, suppressUpdate ) {
         var value = propertyValue;
 
         if ( texture === undefined ) {
@@ -6116,7 +6154,7 @@ define( [ "module",
 
         }
 
-        if ( value !== undefined ) {
+        if ( value !== undefined && !suppressUpdate ) {
             texture.needsUpdate = true;
         }
 

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -5563,6 +5563,13 @@ define( [ "module",
                 obj[ prop ].src = value;
                 obj[ prop ].value = loadTexture( undefined, value );
                 break;
+            case 'tv':
+                var textureArray = [];
+                for ( var i = 0; i < value.length; i++ ) {
+                    textureArray.push( loadTexture( undefined, value[ i ] ) );
+                }
+                obj[ prop ].value = textureArray;
+                break;
         } 
     
     }
@@ -5592,6 +5599,12 @@ define( [ "module",
                     result = loadTexture( undefined, value );
                 }
                 break;
+            case 'tv':
+                result = [];
+                for ( var i = 0; i < value.length; i++ ) {
+                    result.push( loadTexture( undefined, value[ i ] ) );
+                }
+                break;
         }
         return result;
     }
@@ -5611,6 +5624,7 @@ define( [ "module",
         var txt = undefined;
         var url = undefined;
         var mapping = undefined;
+        var wrapTexture = false;
         var onLoad = function( texture ) {
             if ( mat ) {
                 mat.map = texture;
@@ -5629,6 +5643,7 @@ define( [ "module",
         } else {
             url = def.url;
             mapping = def.mapping;
+            wrapTexture = Boolean( def.wrapTexture );
         }
 
         if ( mat === undefined ) {
@@ -5639,6 +5654,10 @@ define( [ "module",
             }
         } else {
             txt = THREE.ImageUtils.loadTexture( url, mapping, onLoad, onError );            
+        }
+
+        if ( wrapTexture ) {
+            txt.wrapS = txt.wrapT = THREE.RepeatWrapping;
         }
 
         return txt;

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1673,6 +1673,9 @@ define( [ "module",
                         } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
+                        } else if ( propertyName === "fog" ) {
+                            value = propertyValue;
+                            threeObject.fog = value;
                         } else if ( threeObject.uniforms.hasOwnProperty( propertyName ) ) {
                             var type = threeObject.uniforms[ propertyName ].type;
                             setUniformProperty( threeObject.uniforms, propertyName, type, propertyValue );

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1657,6 +1657,7 @@ define( [ "module",
                                 defines[ names[ i ] ] = propertyValue[ names[ i ] ];
                             }
                             threeObject.defines = defines;
+                            threeObject.needsUpdate = true;
                         } else if ( propertyName === "vertexShader" ) {
                             value = propertyValue;
                             threeObject.vertexShader = value;
@@ -5598,6 +5599,13 @@ define( [ "module",
                     vectorArray.push( new THREE.Vector2( vector[0], vector[1] ) );
                 }
                 obj[ prop ].value = vectorArray;
+                break;
+            case 'iv1':
+                var intArray = [];
+                for ( var i = 0; i < value.length; i++ ) {
+                    intArray.push( Number( value[ i ] ) );
+                }
+                obj[ prop ].value = intArray;
                 break;
         } 
     

--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -1654,7 +1654,7 @@ define( [ "module",
                         } else if ( propertyName === "lights" ) {
                             value = propertyValue;
                             threeObject.lights = value;
-                        } else if ( !threeObject.hasOwnProperty( propertyName ) ) {
+                        } else {
                             threeObject[ propertyName ] = propertyValue;
                         }
                     }

--- a/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
+++ b/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
@@ -6,6 +6,11 @@ properties:
   ## @name shaderMaterial.vwf#uniforms
   ## @property
   uniforms:
+  ## defines
+  ## 
+  ## @name shaderMaterial.vwf#defines
+  ## @property
+  defines:
   ## Vertex Shader
   ## 
   ## @name shaderMaterial.vwf#vertexShader
@@ -21,4 +26,12 @@ properties:
   ## @name shaderMaterial.vwf#updateFunction
   ## @property
   updateFunction:
-  
+methods:
+  setDefine:
+    parameters:
+      - name
+      - value
+    body: |
+      var defines = this.defines;
+      defines[ name ] = value;
+      this.defines = defines;

--- a/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
+++ b/support/proxy/vwf.example.com/shaderMaterial.vwf.yaml
@@ -35,3 +35,6 @@ methods:
       var defines = this.defines;
       defines[ name ] = value;
       this.defines = defines;
+  updateTexture:
+    parameters:
+      - textureName


### PR DESCRIPTION
- Enabled global ThreeJS inputs for `lights` and `fog`
- Store properties on the materials for use in `updateFunction`
- Allow texture wrapping
- Exposed additional ThreeJS uniform types
- Added functionality for defines
- Added canvas to texture support
- Various fixes
