### PR TITLE
Restrict notifyDriverOfPrototypeAndBehaviorProps to 3D nodes

### DIFF
--- a/support/client/lib/vwf/model/threejs.js
+++ b/support/client/lib/vwf/model/threejs.js
@@ -498,7 +498,7 @@ define( [ "module",
             // If we do not have a load a model for this node, then we are almost done, so we can update all
             // the driver properties w/ the stop-gap function below.
             // Else, it will be called at the end of the assetLoaded callback
-            if ( ! supportedFileType( childType ) ) {
+            if ( node && node.threeObject && !supportedFileType( childType ) ) {
                 notifyDriverOfPrototypeAndBehaviorProps();
             }
 


### PR DESCRIPTION
@davideaster @kadst43 

David, I tested what nodes this portion of the code was hitting by checking for `!node || !node.threeObject` and all of the child ids it spit out were not important to the driver, so I added the check for node and threeObject. The result was a total load time improvement of 6 seconds on my lap top (~28s down to ~22s). The scene remains intact and the game is playable. I didn't notice any issue in testing. Is there any obvious issue I am missing here or does this do the trick?
